### PR TITLE
RequestID middleware cleanup.

### DIFF
--- a/httpx/middleware/request_id_test.go
+++ b/httpx/middleware/request_id_test.go
@@ -10,24 +10,35 @@ import (
 )
 
 func TestRequestID(t *testing.T) {
-	m := &RequestID{
-		handler: httpx.HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-			requestID := httpx.RequestID(ctx)
-
-			if got, want := requestID, "1234"; got != want {
-				t.Fatalf("RequestID => %s; want %s", got, want)
-			}
-
-			return nil
-		}),
+	tests := []struct {
+		header http.Header
+		id     string
+	}{
+		{http.Header{http.CanonicalHeaderKey("X-Request-ID"): []string{"1234"}}, "1234"},
+		{http.Header{http.CanonicalHeaderKey("Request-ID"): []string{"1234"}}, "1234"},
+		{http.Header{http.CanonicalHeaderKey("Foo"): []string{"1234"}}, ""},
 	}
 
-	ctx := context.Background()
-	resp := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/", nil)
-	req.Header.Set("X-Request-ID", "1234")
+	for _, tt := range tests {
+		m := &RequestID{
+			handler: httpx.HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+				requestID := httpx.RequestID(ctx)
 
-	if err := m.ServeHTTPContext(ctx, resp, req); err != nil {
-		t.Fatal(err)
+				if got, want := requestID, tt.id; got != want {
+					t.Fatalf("RequestID => %s; want %s", got, want)
+				}
+
+				return nil
+			}),
+		}
+
+		ctx := context.Background()
+		resp := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/", nil)
+		req.Header = tt.header
+
+		if err := m.ServeHTTPContext(ctx, resp, req); err != nil {
+			t.Fatal(err)
+		}
 	}
 }


### PR DESCRIPTION
Allows you to inject a RequestID extractor into the middleware if you want something different than the defaults. The default now attempts `X-Request-ID` and falls back to `Request-ID`.