### PR TITLE
Extract request body as honeybadger Params

### DIFF
--- a/reporter/hb/hb.go
+++ b/reporter/hb/hb.go
@@ -2,7 +2,9 @@
 package hb
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"reflect"
 	"runtime"
@@ -106,6 +108,8 @@ func NewReport(err error) *Report {
 		for key, value := range e.Context {
 			r.Request.Context[key] = value
 		}
+
+		r.Request.Params = extractParams(e.Request)
 	}
 
 	return r
@@ -121,4 +125,23 @@ func functionName(pc uintptr) string {
 		return "???"
 	}
 	return fn.Name()
+}
+
+// extractParams extracts attempts to extract the body of the request.
+func extractParams(r *http.Request) (m map[string]interface{}) {
+	m = make(map[string]interface{})
+
+	if r == nil {
+		return m
+	}
+
+	defer func() { recover() }()
+
+	if err := json.NewDecoder(r.Body).Decode(&m); err != nil {
+		return
+	}
+
+	// TODO: Parse form
+
+	return
 }

--- a/reporter/hb/test-fixtures/boom-request-json-body-read.json
+++ b/reporter/hb/test-fixtures/boom-request-json-body-read.json
@@ -1,0 +1,36 @@
+{
+  "notifier": {
+    "name": "Honeybadger (Go)",
+    "url": "https://github.com/remind101/pkg/reporter/hb",
+    "version": "0.1",
+    "language": "Go"
+  },
+  "error": {
+    "class": "*errors.errorString",
+    "message": "boom",
+    "backtrace": [],
+    "source": {},
+    "tags": null
+  },
+  "request": {
+    "url": "/",
+    "component": "",
+    "action": "",
+    "params": {},
+    "session": {},
+    "cgi_data": {
+      "HTTP_CONTENT_TYPE": [
+        "application/json"
+      ],
+      "REQUEST_METHOD": "POST"
+    },
+    "context": {
+      "request_id": "1234"
+    }
+  },
+  "server": {
+    "project_root": {},
+    "environment_name": "",
+    "hostname": ""
+  }
+}

--- a/reporter/hb/test-fixtures/boom-request-json-body.json
+++ b/reporter/hb/test-fixtures/boom-request-json-body.json
@@ -1,0 +1,38 @@
+{
+  "notifier": {
+    "name": "Honeybadger (Go)",
+    "url": "https://github.com/remind101/pkg/reporter/hb",
+    "version": "0.1",
+    "language": "Go"
+  },
+  "error": {
+    "class": "*errors.errorString",
+    "message": "boom",
+    "backtrace": [],
+    "source": {},
+    "tags": null
+  },
+  "request": {
+    "url": "/",
+    "component": "",
+    "action": "",
+    "params": {
+      "json": "body"
+    },
+    "session": {},
+    "cgi_data": {
+      "HTTP_CONTENT_TYPE": [
+        "application/json"
+      ],
+      "REQUEST_METHOD": "POST"
+    },
+    "context": {
+      "request_id": "1234"
+    }
+  },
+  "server": {
+    "project_root": {},
+    "environment_name": "",
+    "hostname": ""
+  }
+}


### PR DESCRIPTION
If the request body is json, this will set the params section in honeybadger appropriately.

![](https://s3.amazonaws.com/ejholmes.github.com/MF0JH.png)

In order for this to work properly, it's important that anything that may have read from `r.Body` set it back to an `io.ReadCloser` that reads from the bytes in memory, like:

```go
// Decode json decodes the request body into v.
func Decode(r *http.Request, v interface{}) error {
        raw, err := ioutil.ReadAll(r.Body)
        if err != nil {
                return err
        }

        if err := json.Unmarshal(raw, v); err != nil {
                return err
        }

        // Since we're reading the request from the network, r.Body will return EOF if any
        // downstream code attempts to read it. We set it to a new io.ReadCloser
        // that will read from the bytes in memory.
        r.Body = ioutil.NopCloser(bytes.NewReader(raw))

        return nil
}
```