### PR TITLE
Wrap mux.Route.

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -43,9 +43,9 @@ func main() {
 
 	m := httpx.NewRouter()
 
-	m.Handle("GET", "/ok", httpx.HandlerFunc(ok))
-	m.Handle("GET", "/bad", httpx.HandlerFunc(bad))
-	m.Handle("GET", "/boom", httpx.HandlerFunc(boom))
+	m.HandleFunc("/ok", ok).Methods("GET")
+	m.HandleFunc("/bad", bad).Methods("GET")
+	m.HandleFunc("/boom", boom).Methods("GET")
 
 	var h httpx.Handler
 

--- a/httpx/README.md
+++ b/httpx/README.md
@@ -20,12 +20,14 @@ type Handler interface {
 
 ## Usage
 
+In order to use the `httpx.Handler` interface, you need a compatible router. One is provided within this package that wraps [gorilla mux](https://github.com/gorilla/mux) to make it context.Context aware.
+
 ```go
 r := httpx.NewRouter()
-r.Handle("GET", "/", httpx.HandlerFunc(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+r.HandleFunc("/", func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	io.WriteString(w, `ok`)
 	return nil
-}
+}).Methods("GET")
 
 // Adapt the router to the http.Handler interface and insert a
 // context.Background().

--- a/httpx/httpx.go
+++ b/httpx/httpx.go
@@ -29,4 +29,5 @@ type key int
 const (
 	varsKey key = iota
 	requestIDKey
+	routeKey
 )

--- a/httpx/router_test.go
+++ b/httpx/router_test.go
@@ -25,23 +25,39 @@ func TestRouter(t *testing.T) {
 		// A simple request.
 		{
 			routes: func(r *Router) {
-				r.Handle("GET", "/path", HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+				r.Handle("/path", HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 					io.WriteString(w, ctx.Value("string").(string))
 					return nil
-				}))
+				})).Methods("GET")
 			},
 			req:  newRequest("GET", "/path", nil),
+			body: "foo",
+		},
+
+		// A headers based route.
+		{
+			routes: func(r *Router) {
+				r.Headers("X-Foo", "bar").HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+					io.WriteString(w, ctx.Value("string").(string))
+					return nil
+				})
+			},
+			req: func() *http.Request {
+				r := newRequest("GET", "/path", nil)
+				r.Header.Set("X-Foo", "bar")
+				return r
+			}(),
 			body: "foo",
 		},
 
 		// A request with vars.
 		{
 			routes: func(r *Router) {
-				r.Handle("GET", "/path/{app}", HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+				r.Handle("/path/{app}", HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 					vars := Vars(ctx)
 					io.WriteString(w, vars["app"])
 					return nil
-				}))
+				})).Methods("GET")
 			},
 			req:  newRequest("GET", "/path/acme-inc", nil),
 			body: "acme-inc",

--- a/httpx/router_test.go
+++ b/httpx/router_test.go
@@ -80,6 +80,18 @@ func TestRouter(t *testing.T) {
 			req:  newRequest("GET", "/", nil),
 			body: "not found",
 		},
+
+		// Pulling out current route.
+		{
+			routes: func(r *Router) {
+				r.Handle("/path", HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+					io.WriteString(w, RouteFromContext(ctx).GetName())
+					return nil
+				})).Methods("GET").Name("bar")
+			},
+			req:  newRequest("GET", "/path", nil),
+			body: "bar",
+		},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
This makes the httpx.Router a little more flexible, and opens it up to be able to support all of the methods that gorilla mux supports, by wrapping `mux.Route`.

/cc @bmarini 