### PR TITLE
Honeybadger cannot accept arrays as header values

### DIFF
--- a/reporter/hb/hb.go
+++ b/reporter/hb/hb.go
@@ -105,7 +105,7 @@ func NewReport(err error) *Report {
 				}
 
 				h := strings.Replace(strings.ToUpper(header), "-", "_", -1)
-				r.Request.CgiData["HTTP_"+h] = values
+				r.Request.CgiData["HTTP_"+h] = strings.Join(values, ", ")
 			}
 
 			r.Request.CgiData["REQUEST_METHOD"] = e.Request.Method

--- a/reporter/hb/test-fixtures/boom-request.json
+++ b/reporter/hb/test-fixtures/boom-request.json
@@ -19,12 +19,8 @@
     "params": {},
     "session": {},
     "cgi_data": {
-      "HTTP_CONTENT_TYPE": [
-        "application/json"
-      ],
-      "HTTP_X_FORWARDED_FOR": [
-        "127.0.0.1"
-      ],
+      "HTTP_CONTENT_TYPE": "application/json",
+      "HTTP_X_FORWARDED_FOR": "127.0.0.1",
       "REQUEST_METHOD": "GET"
     },
     "context": {


### PR DESCRIPTION
Got this email from HB:

Howdy!  I see you encountered an error with Honeybadger -- sorry about that!  The problem is that the Go code you are using to send errors to us is sending the web server headers (like HTTP_REFERER) as arrays (with a single string in them) rather than just strings.  For example, a portion of your payload looks like this:

 “HTTP_USER_AGENT":
  ["Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.81 Safari/537.36”]

While it should look like this:

 “HTTP_USER_AGENT":
  "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.81 Safari/537.36”

If you could fix that, you’d be all set.  Thanks!