### PR TITLE
Add retry to pkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ package pkg is a collection of Go packages that provide a layer of convenience o
 * **[logger](./logger)**: Defines a context aware structured logger.
 * **[reporter](./reporter)**: Defines a general abstraction for error reporting, with implementations for honeybadger.
 * **[metrics](./metrics)**: TODO
+* **[retry](./retry)**: Retry function calls with exponential backoff
 
 ## Usage
 

--- a/example/main.go
+++ b/example/main.go
@@ -84,7 +84,7 @@ func ip(ctx context.Context) (string, error) {
 	}
 	req.Header.Set("X-Request-ID", httpx.RequestID(ctx))
 
-	retrier := retry.NewRetrier("ip", retry.DefaultBackOffOpts, func(err error) bool { return true })
+	retrier := retry.NewRetrier("ip", retry.DefaultBackOffOpts, retry.RetryOnAnyError)
 	val, err := retrier.Retry(func() (interface{}, error) { return http.DefaultClient.Do(req) })
 	if err != nil {
 		return "", err

--- a/httpx/middleware/basic_auth.go
+++ b/httpx/middleware/basic_auth.go
@@ -2,9 +2,9 @@ package middleware
 
 import (
 	"encoding/base64"
+	"fmt"
 	"net/http"
 	"strings"
-	"fmt"
 
 	"github.com/remind101/pkg/httpx"
 	"golang.org/x/net/context"
@@ -12,7 +12,7 @@ import (
 
 type BasicAuther struct {
 	User, Pass string
-	Realm string
+	Realm      string
 
 	// The handler that will be called if the request is authorized.
 	Handler httpx.Handler
@@ -41,7 +41,7 @@ func (a *BasicAuther) authenticated(r *http.Request) bool {
 }
 
 func DefaultUnauthorizedHandler(realm string) httpx.HandlerFunc {
-	return httpx.HandlerFunc(func (ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	return httpx.HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 		w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Basic realm=%q`, realm))
 		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 		return nil

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -1,0 +1,142 @@
+package retry
+
+import (
+	"log"
+	"reflect"
+	"time"
+
+	"github.com/cenkalti/backoff"
+)
+
+type BackOffOpts struct {
+	InitialInterval time.Duration
+	MaxInterval     time.Duration
+	MaxElapsedTime  time.Duration
+}
+
+var DefaultBackOffOpts *BackOffOpts = &BackOffOpts{
+	InitialInterval: 500 * time.Millisecond,
+	MaxInterval:     3 * time.Second,
+	MaxElapsedTime:  10 * time.Second}
+
+type RetryNotifier func(*RetryEvent)
+
+type Retrier struct {
+	Name              string
+	backOffOpts       *BackOffOpts
+	shouldRetryFunc   func(error) bool
+	notifyRetryFuncs  []RetryNotifier
+	notifyGaveUpFuncs []RetryNotifier
+}
+
+func NewRetrier(name string,
+	backOffOpts *BackOffOpts, shouldRetryFunc func(error) bool) *Retrier {
+
+	return &Retrier{
+		Name: name, backOffOpts: backOffOpts, shouldRetryFunc: shouldRetryFunc,
+		notifyRetryFuncs:  []RetryNotifier{logRetry},
+		notifyGaveUpFuncs: []RetryNotifier{logGaveUp}}
+}
+
+func NewErrorTypeRetrier(name string,
+	backOffOpts *BackOffOpts, errorTypes ...interface{}) *Retrier {
+
+	return &Retrier{
+		Name:            name,
+		backOffOpts:     backOffOpts,
+		shouldRetryFunc: RetryWhenErrorTypeMatches(instancesToTypes(errorTypes))}
+}
+
+func (r *Retrier) Retry(f func() (interface{}, error)) (interface{}, error) {
+	var val interface{}
+	var err error
+	var next time.Duration
+
+	b := r.newBackOff()
+	b.Reset()
+	for {
+		if val, err = f(); err == nil {
+			return val, nil
+		}
+
+		if !r.shouldRetryFunc(err) {
+			return nil, err
+		}
+
+		if next = b.NextBackOff(); next == backoff.Stop {
+			r.notifyGaveUp(err)
+			return nil, err
+		}
+
+		time.Sleep(next)
+		r.notifyRetry(err)
+	}
+}
+
+type RetryEvent struct {
+	Retrier *Retrier
+	Err     error
+}
+
+func (r *Retrier) AddNotifyRetry(f RetryNotifier) {
+	r.notifyRetryFuncs = append(r.notifyRetryFuncs, f)
+}
+
+func (r *Retrier) AddNotifyGaveUp(f RetryNotifier) {
+	r.notifyGaveUpFuncs = append(r.notifyGaveUpFuncs, f)
+}
+
+func (r *Retrier) notifyGaveUp(err error) {
+	retryEvent := &RetryEvent{Retrier: r, Err: err}
+	for _, notifyGaveUpFunc := range r.notifyGaveUpFuncs {
+		notifyGaveUpFunc(retryEvent)
+	}
+}
+
+func (r *Retrier) notifyRetry(err error) {
+	retryEvent := &RetryEvent{Retrier: r, Err: err}
+	for _, notifyRetryFunc := range r.notifyRetryFuncs {
+		notifyRetryFunc(retryEvent)
+	}
+}
+
+func logRetry(re *RetryEvent) {
+	log.Printf("Retrying error=%s count#retry.%s.retry_count=1\n",
+		re.Err.Error(), re.Retrier.Name)
+}
+
+func logGaveUp(re *RetryEvent) {
+	log.Printf("Retrying error=%s count#retry.%s.gave_up_count=1\n",
+		re.Err.Error(), re.Retrier.Name)
+}
+
+func RetryWhenErrorTypeMatches(errorTypes []reflect.Type) func(error) bool {
+	errorTypeSet := make(map[reflect.Type]bool)
+	for _, t := range errorTypes {
+		errorTypeSet[t] = true
+	}
+	return func(e error) bool {
+		errorType := reflect.TypeOf(e)
+		return errorTypeSet[errorType] == true
+	}
+}
+
+func (r *Retrier) SetBackOffOpts(b *BackOffOpts) {
+	r.backOffOpts = b
+}
+
+func (r *Retrier) newBackOff() backoff.BackOff {
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = r.backOffOpts.InitialInterval
+	b.MaxInterval = r.backOffOpts.MaxInterval
+	b.MaxElapsedTime = r.backOffOpts.MaxElapsedTime
+	return b
+}
+
+func instancesToTypes(instances []interface{}) []reflect.Type {
+	types := []reflect.Type{}
+	for _, instance := range instances {
+		types = append(types, reflect.TypeOf(instance))
+	}
+	return types
+}

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -19,6 +19,8 @@ var DefaultBackOffOpts *BackOffOpts = &BackOffOpts{
 	MaxInterval:     3 * time.Second,
 	MaxElapsedTime:  10 * time.Second}
 
+var RetryOnAnyError = func(error) bool { return true }
+
 type RetryNotifier func(*RetryEvent)
 
 type Retrier struct {

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -57,8 +57,8 @@ func TestRetriesUntilMaxElapsedTimeAndCallsNotifyGaveUp(t *testing.T) {
 	if err != want {
 		t.Fatalf("Expected %v, got %v", err, want)
 	}
-	if counter.Count() <= 10 {
-		t.Fatalf("Expected %v > 10", counter.Count())
+	if counter.Count() < 2 {
+		t.Fatalf("Expected %v >= 2", counter.Count())
 	}
 	if notifyGaveUpCalled != 1 {
 		t.Fatalf("Expected notifygaveup to have been called")

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -1,0 +1,111 @@
+package retry
+
+import (
+	"errors"
+	"reflect"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type MyError struct{}
+
+func (e *MyError) Error() string {
+	return "Error"
+}
+
+type Counter struct {
+	sync.Mutex
+	count int
+}
+
+func (c *Counter) Incr() {
+	c.Lock()
+	defer c.Unlock()
+	c.count++
+}
+
+func (c *Counter) Count() int {
+	return c.count
+}
+
+var _ = Describe("Retrier", func() {
+	var backOffOpts *BackOffOpts
+	var counter *Counter
+
+	BeforeEach(func() {
+		backOffOpts = &BackOffOpts{
+			InitialInterval: 1 * time.Nanosecond,
+			MaxInterval:     5 * time.Nanosecond,
+			MaxElapsedTime:  250 * time.Microsecond}
+		counter = &Counter{}
+	})
+
+	It("keeps retrying until MaxElapsedTime and calls NotifyGaveUp", func() {
+		retrier := NewRetrier("Retrier", backOffOpts, func(error) bool {
+			return true
+		})
+
+		notifyGaveUpCalled := 0
+		retrier.AddNotifyGaveUp(func(*RetryEvent) { notifyGaveUpCalled++ })
+
+		_, err := retrier.Retry(func() (interface{}, error) {
+			counter.Incr()
+			return 0, &MyError{}
+		})
+
+		Expect(err).To(Equal(&MyError{}))
+
+		Expect(counter.Count()).To(BeNumerically(">", 10))
+		Expect(notifyGaveUpCalled).To(Equal(1))
+	})
+
+	It("retries until successful, calling NotifyRetry on each retry", func() {
+		retrier := NewRetrier("Retrier", backOffOpts, func(error) bool {
+			return true
+		})
+
+		notifyRetryCalled := 0
+		retrier.AddNotifyRetry(func(*RetryEvent) { notifyRetryCalled++ })
+
+		iVal, err := retrier.Retry(func() (interface{}, error) {
+			counter.Incr()
+			if counter.Count() < 5 {
+				return 0, &MyError{}
+			} else {
+				return 123, nil
+			}
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		val := iVal.(int)
+		Expect(counter.Count()).To(Equal(5))
+		Expect(val).To(Equal(123))
+
+		// We retried 4 times, for a total of 5 tries.
+		Expect(notifyRetryCalled).To(Equal(4))
+	})
+
+	It("returns the error when there's a non-retryable error", func() {
+		retrier := NewRetrier("Retrier", backOffOpts, func(error) bool {
+			return false
+		})
+		myError := errors.New("myError")
+		_, err := retrier.Retry(func() (interface{}, error) {
+			return nil, myError
+		})
+		Expect(err).To(Equal(myError))
+	})
+})
+
+var _ = Describe("RetryWhenErrorTypeMatches", func() {
+	var MyErrorType = reflect.TypeOf(&MyError{})
+
+	It("returns true when an error matches an expected type", func() {
+		shouldRetryFunc := RetryWhenErrorTypeMatches([]reflect.Type{MyErrorType})
+		Expect(shouldRetryFunc(&MyError{})).To(BeTrue())
+		Expect(shouldRetryFunc(errors.New("hi"))).To(BeFalse())
+	})
+})


### PR DESCRIPTION
Extracted from hermes. I want to reuse this for events. Once this is out, I'll delete the implementation in hermes and use this.

Example: 
```
12:06 $ go run ./example/main.go
request_id= request.start method=GET path=/ok
2015/06/18 12:06:42 Retrying error=Get http://api.ipasdasdaify.org?format=text: dial tcp: lookup api.ipasdasdaify.org: no such host count#retry.ip.retry_count=1
2015/06/18 12:06:43 Retrying error=Get http://api.ipasdasdaify.org?format=text: dial tcp: lookup api.ipasdasdaify.org: no such host count#retry.ip.retry_count=1
2015/06/18 12:06:44 Retrying error=Get http://api.ipasdasdaify.org?format=text: dial tcp: lookup api.ipasdasdaify.org: no such host count#retry.ip.retry_count=1
2015/06/18 12:06:46 Retrying error=Get http://api.ipasdasdaify.org?format=text: dial tcp: lookup api.ipasdasdaify.org: no such host count#retry.ip.retry_count=1
2015/06/18 12:06:48 Retrying error=Get http://api.ipasdasdaify.org?format=text: dial tcp: lookup api.ipasdasdaify.org: no such host count#retry.ip.retry_count=1
2015/06/18 12:06:52 Retrying error=Get http://api.ipasdasdaify.org?format=text: dial tcp: lookup api.ipasdasdaify.org: no such host count#retry.ip.retry_count=1
2015/06/18 12:06:52 Retrying error=Get http://api.ipasdasdaify.org?format=text: dial tcp: lookup api.ipasdasdaify.org: no such host count#retry.ip.gave_up_count=1
request_id= request.complete status=500
^Cexit status 2
```

cc @sumeet @bmarini 