### PR TITLE
Make context available to middleware.ErrorHandlerFunc

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -34,7 +34,7 @@ func boom(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	panic("boom")
 }
 
-func errorHandler(err error, w http.ResponseWriter, r *http.Request) {
+func errorHandler(ctx context.Context, err error, w http.ResponseWriter, r *http.Request) {
 	http.Error(w, err.Error(), http.StatusInternalServerError)
 }
 

--- a/httpx/middleware/error_test.go
+++ b/httpx/middleware/error_test.go
@@ -40,7 +40,7 @@ func TestErrorWithHandler(t *testing.T) {
 	var called bool
 
 	h := &Error{
-		ErrorHandler: func(err error, w http.ResponseWriter, r *http.Request) {
+		ErrorHandler: func(ctx context.Context, err error, w http.ResponseWriter, r *http.Request) {
 			called = true
 		},
 		handler: httpx.HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {


### PR DESCRIPTION
This allows access to reporter or logger embedded in the context, and anything else (request id, etc)