### PR TITLE
Add reporter.hb2 - uses native Honeybadger client

### DIFF
--- a/reporter/hb2/hb2.go
+++ b/reporter/hb2/hb2.go
@@ -1,0 +1,77 @@
+// package hb2 is a Go package for sending errors to Honeybadger
+// using the official client library
+package hb2
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/honeybadger-io/honeybadger-go"
+	"github.com/remind101/pkg/reporter"
+	"golang.org/x/net/context"
+)
+
+// Headers that won't be sent to honeybadger.
+var IgnoredHeaders = map[string]struct{}{
+	"Authorization": struct{}{},
+}
+
+type Config struct {
+	ApiKey      string
+	Environment string
+	Endpoint    string
+}
+
+type hbReporter struct {
+	client *honeybadger.Client
+}
+
+// NewReporter returns a new Reporter instance.
+func NewReporter(cfg Config) *hbReporter {
+	hbCfg := honeybadger.Configuration{}
+	hbCfg.APIKey = cfg.ApiKey
+	hbCfg.Env = cfg.Environment
+	hbCfg.Endpoint = cfg.Endpoint
+
+	return &hbReporter{honeybadger.New(hbCfg)}
+}
+
+// Report reports the error to honeybadger.
+func (r *hbReporter) Report(ctx context.Context, err error) error {
+	extras := []interface{}{}
+
+	if e, ok := err.(*reporter.Error); ok {
+		extras = append(extras, getContextData(e))
+		if r := e.Request; r != nil {
+			extras = append(extras, honeybadger.Params(r.Form), getRequestData(r), *r.URL)
+		}
+		err = e.Err
+	}
+
+	_, clientErr := r.client.Notify(err, extras...)
+	return clientErr
+}
+
+func getRequestData(r *http.Request) honeybadger.CGIData {
+	cgiData := honeybadger.CGIData{}
+	replacer := strings.NewReplacer("-", "_")
+
+	for header, values := range r.Header {
+		if _, ok := IgnoredHeaders[header]; ok {
+			continue
+		}
+		key := "HTTP_" + replacer.Replace(strings.ToUpper(header))
+		cgiData[key] = strings.Join(values, ",")
+	}
+
+	cgiData["REQUEST_METHOD"] = r.Method
+	return cgiData
+}
+
+func getContextData(err *reporter.Error) honeybadger.Context {
+	ctx := honeybadger.Context{}
+	for key, value := range err.Context {
+		ctx[key] = value
+	}
+	return ctx
+}

--- a/reporter/hb2/hb2_test.go
+++ b/reporter/hb2/hb2_test.go
@@ -1,0 +1,132 @@
+package hb2
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/remind101/pkg/reporter"
+)
+
+func TestHb2IsReporter(t *testing.T) {
+	var _ reporter.Reporter = NewReporter(Config{})
+}
+
+func TestHb2ReportsErrorContext(t *testing.T) {
+	h := newFakeHoneybadgerHandler(t)
+	ts := httptest.NewServer(h)
+	defer ts.Close()
+	r := NewReporter(Config{Endpoint: ts.URL})
+
+	boom := errors.New("The Error")
+	tests := []struct {
+		name string
+		err  error
+		path string
+		want map[string]interface{}
+	}{
+		{
+			name: "error with context",
+			err: &reporter.Error{
+				Err: boom,
+				Context: map[string]interface{}{
+					"lol": "wut",
+				},
+			},
+			path: "request.context",
+			want: map[string]interface{}{
+				"lol": "wut",
+			},
+		},
+		{
+			name: "error during request",
+			err: &reporter.Error{
+				Err: boom,
+				Context: map[string]interface{}{
+					"request_id": "1234",
+				},
+				Request: func() *http.Request {
+					form := url.Values{}
+					form.Add("param1", "param1value")
+					req, _ := http.NewRequest("GET", "/api/foo", nil)
+					req.Header.Set("Content-Type", "application/json")
+					req.Header.Set("X-Forwarded-For", "127.0.0.1")
+					req.Header.Set("Authorization", "Basic shouldnotseeit")
+					req.Form = form
+					return req
+				}(),
+			},
+			path: "request",
+			want: map[string]interface{}{
+				"cgi_data": map[string]interface{}{
+					"HTTP_CONTENT_TYPE":    "application/json",
+					"HTTP_X_FORWARDED_FOR": "127.0.0.1",
+					"REQUEST_METHOD":       "GET",
+				},
+				"context": map[string]interface{}{
+					"request_id": "1234",
+				},
+				"params": map[string]interface{}{
+					"param1": []interface{}{
+						"param1value",
+					},
+				},
+				"url": "/api/foo",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		r.Report(context.Background(), tt.err)
+
+		select {
+		case v := <-h.LastRequestBodyChan:
+			got, want := atPath(v, tt.path), tt.want
+			if !reflect.DeepEqual(got, want) {
+				jsonGot, _ := json.MarshalIndent(got, "", "  ")
+				jsonWant, _ := json.MarshalIndent(want, "", "  ")
+				t.Errorf("[%s]\n got %s\nwant %s", tt.name, jsonGot, jsonWant)
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatalf("did not report to HB in 3 seconds")
+		}
+	}
+
+}
+
+func newFakeHoneybadgerHandler(t *testing.T) *fakeHoneybadgerHandler {
+	return &fakeHoneybadgerHandler{make(chan map[string]interface{}, 1), t}
+}
+
+type fakeHoneybadgerHandler struct {
+	LastRequestBodyChan chan map[string]interface{}
+	T                   *testing.T
+}
+
+func (h *fakeHoneybadgerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	decoder := json.NewDecoder(r.Body)
+	v := map[string]interface{}{}
+	err := decoder.Decode(&v)
+	if err != nil {
+		h.T.Fatalf("not a valid json in request to Honeybadger")
+	}
+	h.LastRequestBodyChan <- v
+	w.WriteHeader(http.StatusCreated)
+}
+
+func atPath(v map[string]interface{}, path string) map[string]interface{} {
+	for _, p := range strings.Split(path, ".") {
+		if p != "" {
+			v = v[p].(map[string]interface{})
+		}
+	}
+	return v
+}


### PR DESCRIPTION
Pretty much no bonuses over our client, to be honest - mem/load reporting.
HB generates stack trace on its own, reporter.Error-generated stacktrace is discarded.
Stack trace will always get first two lines in reporters, which sucks.
@bmarini @sanjayprabhu 

<img width="703" alt="screen shot 2015-07-21 at 3 10 58 pm" src="https://cloud.githubusercontent.com/assets/472161/8813807/1c13258e-2fbb-11e5-9c10-ed2b1dbf7e25.png">
