### PR TITLE
Log the number of tries.

### DIFF
--- a/retry/retry.go
+++ b/retry/retry.go
@@ -107,12 +107,12 @@ func (r *Retrier) notifyRetry(err error, numTries int) {
 
 func logRetry(re *RetryEvent) {
 	log.Printf("Retrying after %d tries: error=%s count#retry.%s.retry_count=1\n",
-		re.Err.Error(), re.Retrier.Name, re.NumTries)
+		re.NumTries, re.Err.Error(), re.Retrier.Name)
 }
 
 func logGaveUp(re *RetryEvent) {
 	log.Printf("Giving up after %d tries: error=%s count#retry.%s.gave_up_count=1\n",
-		re.Err.Error(), re.Retrier.Name, re.NumTries)
+		re.NumTries, re.Err.Error(), re.Retrier.Name)
 }
 
 func RetryWhenErrorTypeMatches(errorTypes []reflect.Type) func(error) bool {


### PR DESCRIPTION
Log number of tries when retrying and giving up:

```
14:09:13 Retrying after 1 tries: error=connection refused count#retry.redshift.retry_count=1
14:09:13 Giving up after 2 tries: error=connection refused count#retry.redshift.gave_up_count=1
```

Whereas the retry_count and gave_up_count vars at the end of those lines always have value "1" because they are designed for aggregation, the "after N tries" bit at the beginning of the loglines (added by this PR) allow you to look at a single line in SumoLogic and understand how many tries have occurred. (This will help me debug a case where I'm not seeing any retry lines before the gave_up line and I think I should.)

@v-yarotsky 