### PR TITLE
Retrier logging improvements.

### DIFF
--- a/retry/retry.go
+++ b/retry/retry.go
@@ -1,8 +1,10 @@
 package retry
 
 import (
+	"fmt"
 	"log"
 	"reflect"
+	"sync/atomic"
 	"time"
 
 	"github.com/cenkalti/backoff"
@@ -24,20 +26,26 @@ var RetryOnAnyError = func(error) bool { return true }
 type RetryNotifier func(*RetryEvent)
 
 type Retrier struct {
-	Name              string
-	backOffOpts       *BackOffOpts
-	shouldRetryFunc   func(error) bool
-	notifyRetryFuncs  []RetryNotifier
-	notifyGaveUpFuncs []RetryNotifier
+	Name                      string
+	backOffOpts               *BackOffOpts
+	shouldRetryFunc           func(error) bool
+	notifyRetryFuncs          []RetryNotifier
+	notifyGaveUpFuncs         []RetryNotifier
+	notifyShouldNotRetryFuncs []RetryNotifier
 }
+
+var retrierNum uint32 = 0
 
 func NewRetrier(name string,
 	backOffOpts *BackOffOpts, shouldRetryFunc func(error) bool) *Retrier {
 
 	return &Retrier{
-		Name: name, backOffOpts: backOffOpts, shouldRetryFunc: shouldRetryFunc,
-		notifyRetryFuncs:  []RetryNotifier{logRetry},
-		notifyGaveUpFuncs: []RetryNotifier{logGaveUp}}
+		Name:                      fmt.Sprintf("%s%d", name, atomic.AddUint32(&retrierNum, 1)),
+		backOffOpts:               backOffOpts,
+		shouldRetryFunc:           shouldRetryFunc,
+		notifyRetryFuncs:          []RetryNotifier{logRetry},
+		notifyGaveUpFuncs:         []RetryNotifier{logGaveUp},
+		notifyShouldNotRetryFuncs: []RetryNotifier{logShouldNotRetry}}
 }
 
 func NewErrorTypeRetrier(name string,
@@ -64,6 +72,7 @@ func (r *Retrier) Retry(f func() (interface{}, error)) (interface{}, error) {
 		}
 
 		if !r.shouldRetryFunc(err) {
+			r.notifyShouldNotRetry(err, numTries)
 			return val, err
 		}
 
@@ -91,6 +100,13 @@ func (r *Retrier) AddNotifyGaveUp(f RetryNotifier) {
 	r.notifyGaveUpFuncs = append(r.notifyGaveUpFuncs, f)
 }
 
+func (r *Retrier) notifyShouldNotRetry(err error, numTries int) {
+	retryEvent := &RetryEvent{Retrier: r, Err: err, NumTries: numTries}
+	for _, notifyNoRetryFunc := range r.notifyShouldNotRetryFuncs {
+		notifyNoRetryFunc(retryEvent)
+	}
+}
+
 func (r *Retrier) notifyGaveUp(err error, numTries int) {
 	retryEvent := &RetryEvent{Retrier: r, Err: err, NumTries: numTries}
 	for _, notifyGaveUpFunc := range r.notifyGaveUpFuncs {
@@ -103,6 +119,11 @@ func (r *Retrier) notifyRetry(err error, numTries int) {
 	for _, notifyRetryFunc := range r.notifyRetryFuncs {
 		notifyRetryFunc(retryEvent)
 	}
+}
+
+func logShouldNotRetry(re *RetryEvent) {
+	log.Printf("Error not qualified for retry: error=%s count#retry.%s.no_retry=1\n",
+		re.Err.Error(), re.Retrier.Name)
 }
 
 func logRetry(re *RetryEvent) {


### PR DESCRIPTION
What do you think about this change as a permanent addition?
- Adds retrier number to name (unique within a process);
- Logs when not retrying because shouldRetryFunc returned false.

@v-yarotsky 