### PR TITLE
Make retry_test more robust in the face of test system slowness.

### DIFF
--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -33,7 +33,7 @@ func createRetrier(shouldRetry func(error) bool) (*Retrier, *Counter) {
 	backOffOpts := &BackOffOpts{
 		InitialInterval: 1 * time.Nanosecond,
 		MaxInterval:     5 * time.Nanosecond,
-		MaxElapsedTime:  250 * time.Microsecond}
+		MaxElapsedTime:  250 * time.Millisecond}
 	counter := &Counter{}
 
 	return NewRetrier("Retrier", backOffOpts, shouldRetry), counter


### PR DESCRIPTION
Because anything can happen in 250 microseconds, e.g. https://travis-ci.org/remind101/pkg/builds/108886764 .

(The retrier uses clock time to evaluate whether it's been too long and should give up. If the test environment does something else for [MaxElapsedTime - epsilon], a test that should have succeeded will fail.)

@psocha @v-yarotsky 