### PR TITLE
Return error when there is no reporter in the given context.

### DIFF
--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -3,7 +3,6 @@
 package reporter
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"runtime"
@@ -75,7 +74,7 @@ func Report(ctx context.Context, err error) error {
 	if r, ok := FromContext(ctx); ok {
 		return r.Report(ctx, e)
 	} else {
-		return errors.New("No reporter in provided context.")
+		panic("No reporter in provided context.")
 	}
 
 	return nil

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -73,6 +73,8 @@ func Report(ctx context.Context, err error) error {
 
 	if r, ok := FromContext(ctx); ok {
 		return r.Report(ctx, e)
+	} else {
+		return errors.New("No reporter in provided context.")
 	}
 
 	return nil

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -3,6 +3,7 @@
 package reporter
 
 import (
+  "errors"
 	"fmt"
 	"net/http"
 	"runtime"

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -3,7 +3,7 @@
 package reporter
 
 import (
-  "errors"
+	"errors"
 	"fmt"
 	"net/http"
 	"runtime"

--- a/reporter/reporter_test.go
+++ b/reporter/reporter_test.go
@@ -40,6 +40,13 @@ func TestReport(t *testing.T) {
 	}
 }
 
+func TestReportWithNoReporterInContext(t *testing.T) {
+	ctx := context.Background() // no reporter
+	if err := Report(ctx, errBoom); err == nil {
+		t.Error("Expected Report to return an error, got none")
+	}
+}
+
 func TestMonitor(t *testing.T) {
 	ensureRepanicked := func() {
 		if v := recover(); v == nil {

--- a/reporter/reporter_test.go
+++ b/reporter/reporter_test.go
@@ -41,10 +41,13 @@ func TestReport(t *testing.T) {
 }
 
 func TestReportWithNoReporterInContext(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("Expected panic due to context without reporter, got no panic")
+		}
+	}()
 	ctx := context.Background() // no reporter
-	if err := Report(ctx, errBoom); err == nil {
-		t.Error("Expected Report to return an error, got none")
-	}
+	Report(ctx, errBoom)
 }
 
 func TestMonitor(t *testing.T) {


### PR DESCRIPTION
@ejholmes 
cc @sanjayprabhu 

A context can lack a reporter. Before this change, reporter.Report(ctx, err) would return success without reporting anything in that case.

This is a potentially breaking change, e.g. if some caller panics on an error from this function and doesn't realizes it's passing a context without a reporter. But then, that would be a bug we'd want to catch.