### PR TITLE
mark the request as internal server error in recovery

### DIFF
--- a/httpx/middleware/recovery.go
+++ b/httpx/middleware/recovery.go
@@ -39,6 +39,8 @@ func (h *Recovery) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, 
 
 	defer func() {
 		if v := recover(); v != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+
 			err = fmt.Errorf("%v", v)
 
 			if v, ok := v.(error); ok {


### PR DESCRIPTION
If we catch an error in the middleware, we should mark the incoming request as failed too.