### PR TITLE
update honeybadger to latest version

### DIFF
--- a/reporter/hb2/internal/honeybadger-go/.gitignore
+++ b/reporter/hb2/internal/honeybadger-go/.gitignore
@@ -1,0 +1,26 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+cover.out

--- a/reporter/hb2/internal/honeybadger-go/.travis.yml
+++ b/reporter/hb2/internal/honeybadger-go/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+install: make deps
+go:
+  - 1.4
+  - 1.5
+  - 1.6
+  - tip

--- a/reporter/hb2/internal/honeybadger-go/CHANGELOG.md
+++ b/reporter/hb2/internal/honeybadger-go/CHANGELOG.md
@@ -5,6 +5,26 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+## [0.2.0] - 2016-10-14
+### Changed
+- Sunset performance metrics. See
+  http://blog.honeybadger.io/sunsetting-performance-metrics/
+
+## [0.1.0] - 2016-05-12
+### Added
+- Use `honeybadger.MetricsHandler` to send us request metrics!
+
+## [0.0.3] - 2016-04-13
+### Added
+- `honeybadger.NewNullBackend()`: creates a backend which swallows all errors
+  and does not send them to Honeybadger. This is useful for development and
+  testing to disable sending unnecessary errors. -@gaffneyc
+- Tested against Go 1.5 and 1.6. -@gaffneyc
+
+### Fixed
+- Export Fingerprint fields. -@smeriwether
+- Fix HB due to changes in shirou/gopsutil. -@kostyantyn
+
 ## [0.0.2] - 2016-03-28
 ### Added
 - Make newError function public (#6). -@kostyantyn

--- a/reporter/hb2/internal/honeybadger-go/Makefile
+++ b/reporter/hb2/internal/honeybadger-go/Makefile
@@ -4,6 +4,9 @@ deps:
 	# dependencies
 	go get github.com/pborman/uuid
 	go get github.com/shirou/gopsutil/load
+	# testing libs
+	go get github.com/stretchr/testify/mock
+	go get github.com/stretchr/testify/assert
 
 prepare: deps
 	# needed for `make fmt`

--- a/reporter/hb2/internal/honeybadger-go/README.md
+++ b/reporter/hb2/internal/honeybadger-go/README.md
@@ -73,6 +73,7 @@ if err != nil {
 }
 ```
 
+
 ## Sample Application
 
 If you'd like to see the library in action before you integrate it with your apps, check out our [sample application](https://github.com/honeybadger-io/crywolf-go). 
@@ -216,6 +217,17 @@ honeybadger.BeforeNotify(
 )
 ```
 
+---
+
+### ``honeybadger.NewNullBackend()``: Disable data reporting.
+
+`NewNullBackend` creates a backend which swallows all errors and does not send them to Honeybadger. This is useful for development and testing to disable sending unnecessary errors.
+
+#### Examples:
+
+```go
+honeybadger.Configure(honeybadger.Configuration{Backend: honeybadger.NewNullBackend()})
+```
 
 ---
 

--- a/reporter/hb2/internal/honeybadger-go/client.go
+++ b/reporter/hb2/internal/honeybadger-go/client.go
@@ -3,6 +3,7 @@ package honeybadger
 import (
 	"net/http"
 	"strings"
+	"time"
 )
 
 // The Payload interface is implemented by any type which can be handled by the
@@ -99,10 +100,33 @@ func (client *Client) Handler(h http.Handler) http.Handler {
 	return http.HandlerFunc(fn)
 }
 
+// MetricsHandler is deprecated.
+func (client *Client) MetricsHandler(h http.Handler) http.Handler {
+	client.Config.Logger.Printf("DEPRECATION WARNING: honeybadger.MetricsHandler() has no effect and will be removed.")
+	if h == nil {
+		h = http.DefaultServeMux
+	}
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		h.ServeHTTP(w, r)
+	}
+	return http.HandlerFunc(fn)
+}
+
+// Increment is deprecated.
+func (client *Client) Increment(metric string, value int) {
+	client.Config.Logger.Printf("DEPRECATION WARNING: honeybadger.Increment() has no effect and will be removed.")
+}
+
+// Timing is deprecated.
+func (client *Client) Timing(metric string, value time.Duration) {
+	client.Config.Logger.Printf("DEPRECATION WARNING: honeybadger.Timing() has no effect and will be removed.")
+}
+
 // New returns a new instance of Client.
 func New(c Configuration) *Client {
 	config := newConfig(c)
 	worker := newBufferedWorker(config)
+
 	client := Client{
 		Config:  config,
 		worker:  worker,

--- a/reporter/hb2/internal/honeybadger-go/configuration.go
+++ b/reporter/hb2/internal/honeybadger-go/configuration.go
@@ -15,14 +15,15 @@ type Logger interface {
 
 // Configuration manages the configuration for the client.
 type Configuration struct {
-	APIKey   string
-	Root     string
-	Env      string
-	Hostname string
-	Endpoint string
-	Timeout  time.Duration
-	Logger   Logger
-	Backend  Backend
+	APIKey          string
+	Root            string
+	Env             string
+	Hostname        string
+	Endpoint        string
+	Timeout         time.Duration
+	Logger          Logger
+	Backend         Backend
+	MetricsInterval time.Duration
 }
 
 func (c1 *Configuration) update(c2 *Configuration) *Configuration {
@@ -50,18 +51,22 @@ func (c1 *Configuration) update(c2 *Configuration) *Configuration {
 	if c2.Backend != nil {
 		c1.Backend = c2.Backend
 	}
+	if c2.MetricsInterval > 0 {
+		c1.MetricsInterval = c2.MetricsInterval
+	}
 	return c1
 }
 
 func newConfig(c Configuration) *Configuration {
 	config := &Configuration{
-		APIKey:   getEnv("HONEYBADGER_API_KEY"),
-		Root:     getPWD(),
-		Env:      getEnv("HONEYBADGER_ENV"),
-		Hostname: getHostname(),
-		Endpoint: getEnv("HONEYBADGER_ENDPOINT", "https://api.honeybadger.io"),
-		Timeout:  getTimeout(),
-		Logger:   log.New(os.Stderr, "[honeybadger] ", log.Flags()),
+		APIKey:          getEnv("HONEYBADGER_API_KEY"),
+		Root:            getPWD(),
+		Env:             getEnv("HONEYBADGER_ENV"),
+		Hostname:        getHostname(),
+		Endpoint:        getEnv("HONEYBADGER_ENDPOINT", "https://api.honeybadger.io"),
+		Timeout:         getTimeout(),
+		Logger:          log.New(os.Stderr, "[honeybadger] ", log.Flags()),
+		MetricsInterval: 60 * time.Second,
 	}
 	config.update(&c)
 

--- a/reporter/hb2/internal/honeybadger-go/honeybadger.go
+++ b/reporter/hb2/internal/honeybadger-go/honeybadger.go
@@ -1,12 +1,14 @@
 package honeybadger
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/url"
+	"time"
 )
 
 // VERSION defines the version of the honeybadger package.
-const VERSION = "0.0.2"
+const VERSION = "0.2.0"
 
 var (
 	// client is a pre-defined "global" client.
@@ -17,6 +19,9 @@ var (
 
 	// Notices is the feature for sending error reports.
 	Notices = Feature{"notices"}
+
+	// Metrics is deprecated.
+	Metrics = Feature{"metrics"}
 )
 
 // Feature references a resource provided by the API service. Its Endpoint maps
@@ -33,6 +38,17 @@ type CGIData hash
 
 // Params stores the form or url values from an HTTP request.
 type Params url.Values
+
+// hash is used internally to construct JSON payloads.
+type hash map[string]interface{}
+
+func (h *hash) toJSON() []byte {
+	out, err := json.Marshal(h)
+	if err == nil {
+		return out
+	}
+	panic(err)
+}
 
 // Configure updates configuration of the global client.
 func Configure(c Configuration) {
@@ -83,9 +99,24 @@ func Handler(h http.Handler) http.Handler {
 	return DefaultClient.Handler(h)
 }
 
+// MetricsHandler is deprecated.
+func MetricsHandler(h http.Handler) http.Handler {
+	return DefaultClient.MetricsHandler(h)
+}
+
 // BeforeNotify adds a callback function which is run before a notice is
 // reported to Honeybadger. If any function returns an error the notification
 // will be skipped, otherwise it will be sent.
 func BeforeNotify(handler func(notice *Notice) error) {
 	DefaultClient.BeforeNotify(handler)
+}
+
+// Increment is deprecated.
+func Increment(metric string, value int) {
+	DefaultClient.Increment(metric, value)
+}
+
+// Timing is deprecated.
+func Timing(metric string, value time.Duration) {
+	DefaultClient.Timing(metric, value)
 }

--- a/reporter/hb2/internal/honeybadger-go/honeybadger_test.go
+++ b/reporter/hb2/internal/honeybadger-go/honeybadger_test.go
@@ -9,7 +9,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/remind101/pkg/reporter/hb2/internal/uuid"
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/mock"
 )
 
 var (
@@ -18,6 +19,14 @@ var (
 	requests      []*HTTPRequest
 	defaultConfig = *Config
 )
+
+type MockedHandler struct {
+	mock.Mock
+}
+
+func (h *MockedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.Called()
+}
 
 type HTTPRequest struct {
 	Request *http.Request
@@ -252,6 +261,31 @@ func testNoticePayload(t *testing.T, payload hash) bool {
 		}
 	}
 	return true
+}
+
+func TestHandlerCallsHandler(t *testing.T) {
+	mockHandler := &MockedHandler{}
+	mockHandler.On("ServeHTTP").Return()
+
+	handler := Handler(mockHandler)
+	req, _ := http.NewRequest("GET", "", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	mockHandler.AssertCalled(t, "ServeHTTP")
+}
+
+func TestMetricsHandlerCallsHandler(t *testing.T) {
+	mockHandler := &MockedHandler{}
+	mockHandler.On("ServeHTTP").Return()
+
+	metricsHandler := MetricsHandler(mockHandler)
+
+	req, _ := http.NewRequest("GET", "", nil)
+	w := httptest.NewRecorder()
+	metricsHandler.ServeHTTP(w, req)
+
+	mockHandler.AssertCalled(t, "ServeHTTP")
 }
 
 func assertMethod(t *testing.T, r *http.Request, method string) {

--- a/reporter/hb2/internal/honeybadger-go/notice.go
+++ b/reporter/hb2/internal/honeybadger-go/notice.go
@@ -7,12 +7,10 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/remind101/pkg/reporter/hb2/internal/uuid"
-	"github.com/remind101/pkg/reporter/hb2/internal/gopsutil/load"
-	"github.com/remind101/pkg/reporter/hb2/internal/gopsutil/mem"
+	"github.com/pborman/uuid"
+	"github.com/shirou/gopsutil/load"
+	"github.com/shirou/gopsutil/mem"
 )
-
-type hash map[string]interface{}
 
 // ErrorClass represents the class name of the error which is sent to
 // Honeybadger.
@@ -23,11 +21,11 @@ type ErrorClass struct {
 // Fingerprint represents the fingerprint of the error, which controls grouping
 // in Honeybadger.
 type Fingerprint struct {
-	content string
+	Content string
 }
 
 func (f *Fingerprint) String() string {
-	return f.content
+	return f.Content
 }
 
 // Notice is a representation of the error which is sent to Honeybadger, and
@@ -98,7 +96,7 @@ func getStats() *hash {
 		}
 	}
 
-	if stat, err := load.LoadAvg(); err == nil {
+	if stat, err := load.Avg(); err == nil {
 		l = &hash{
 			"one":     stat.Load1,
 			"five":    stat.Load5,

--- a/reporter/hb2/internal/honeybadger-go/null_backend.go
+++ b/reporter/hb2/internal/honeybadger-go/null_backend.go
@@ -1,0 +1,20 @@
+package honeybadger
+
+// nullBackend implements the Backend interface but swallows errors and does not
+// send them to Honeybadger.
+type nullBackend struct{}
+
+// Ensure nullBackend implements Backend.
+var _ Backend = &nullBackend{}
+
+// NewNullBackend creates a backend which swallows all errors and does not send
+// them to Honeybadger. This is useful for development and testing to disable
+// sending unnecessary errors.
+func NewNullBackend() Backend {
+	return nullBackend{}
+}
+
+// Notify swallows error reports, does nothing, and returns no error.
+func (b nullBackend) Notify(_ Feature, _ Payload) error {
+	return nil
+}


### PR DESCRIPTION
This will enable overriding the error class name which honeybadger uses to group error instances.

```
honeybadger.Notify(err, honeybadger.ErrorClass{"CustomClassName"})
```

This is the result of running:
```
rm -rf reporter/hb2/internal/honeybadger-go
cd reporter/hb2/internal
git clone git@github.com:honeybadger-io/honeybadger-go.git
rm -rf honeybadger-go/.git
```