### PR TITLE
[RFC] Refactor error handling to expose accurate stack traces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea
+*.swo
+*.swp

--- a/httpx/middleware/recovery.go
+++ b/httpx/middleware/recovery.go
@@ -1,9 +1,9 @@
 package middleware
 
 import (
-	"fmt"
 	"net/http"
 
+	"github.com/pkg/errors"
 	"github.com/remind101/pkg/httpx"
 	"github.com/remind101/pkg/reporter"
 	"golang.org/x/net/context"
@@ -41,14 +41,12 @@ func (h *Recovery) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, 
 		if v := recover(); v != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 
-			err = fmt.Errorf("%v", v)
-
-			if v, ok := v.(error); ok {
-				err = v
+			err, ok := v.(error)
+			if !ok {
+				err = errors.Errorf("%v", v)
 			}
 
 			reporter.Report(ctx, err)
-
 			return
 		}
 	}()

--- a/httpx/middleware/recovery.go
+++ b/httpx/middleware/recovery.go
@@ -41,7 +41,8 @@ func (h *Recovery) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, 
 		if v := recover(); v != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 
-			err, ok := v.(error)
+			var ok bool
+			err, ok = v.(error)
 			if !ok {
 				err = errors.Errorf("%v", v)
 			}

--- a/httpx/middleware/recovery.go
+++ b/httpx/middleware/recovery.go
@@ -1,9 +1,9 @@
 package middleware
 
 import (
+	"fmt"
 	"net/http"
 
-	"github.com/pkg/errors"
 	"github.com/remind101/pkg/httpx"
 	"github.com/remind101/pkg/reporter"
 	"golang.org/x/net/context"
@@ -42,9 +42,8 @@ func (h *Recovery) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, 
 			w.WriteHeader(http.StatusInternalServerError)
 
 			var ok bool
-			err, ok = v.(error)
-			if !ok {
-				err = errors.Errorf("%v", v)
+			if err, ok = v.(error); !ok {
+				err = fmt.Errorf("%v", v)
 			}
 
 			reporter.Report(ctx, err)

--- a/reporter/hb2/hb2.go
+++ b/reporter/hb2/hb2.go
@@ -3,11 +3,14 @@
 package hb2
 
 import (
+	"fmt"
 	"net/http"
+	"reflect"
 	"strings"
 
-	"github.com/remind101/pkg/reporter/hb2/internal/honeybadger-go"
+	"github.com/pkg/errors"
 	"github.com/remind101/pkg/reporter"
+	"github.com/remind101/pkg/reporter/hb2/internal/honeybadger-go"
 	"golang.org/x/net/context"
 )
 
@@ -36,6 +39,29 @@ func NewReporter(cfg Config) *hbReporter {
 	return &hbReporter{honeybadger.New(hbCfg)}
 }
 
+func makeHoneybadgerFrames(stack errors.StackTrace) []*honeybadger.Frame {
+	length := len(stack)
+	frames := make([]*honeybadger.Frame, length)
+	for index, frame := range stack[:length] {
+		frames[index] = &honeybadger.Frame{
+			Number: fmt.Sprintf("%d", frame),
+			File:   fmt.Sprintf("%s", frame),
+			Method: fmt.Sprintf("%n", frame),
+		}
+	}
+	return frames
+}
+
+func makeHoneybadgerError(err *reporter.Error) honeybadger.Error {
+	cause := err.Cause()
+	frames := makeHoneybadgerFrames(err.StackTrace())
+	return honeybadger.Error{
+		Message: err.Error(),
+		Class:   reflect.TypeOf(cause).String(),
+		Stack:   frames,
+	}
+}
+
 // Report reports the error to honeybadger.
 func (r *hbReporter) Report(ctx context.Context, err error) error {
 	extras := []interface{}{}
@@ -45,7 +71,7 @@ func (r *hbReporter) Report(ctx context.Context, err error) error {
 		if r := e.Request; r != nil {
 			extras = append(extras, honeybadger.Params(r.Form), getRequestData(r), *r.URL)
 		}
-		err = e.Err
+		err = makeHoneybadgerError(e)
 	}
 
 	_, clientErr := r.client.Notify(err, extras...)

--- a/reporter/logger.go
+++ b/reporter/logger.go
@@ -3,6 +3,7 @@ package reporter
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/remind101/pkg/logger"
 	"golang.org/x/net/context"
 )
@@ -16,23 +17,20 @@ func NewLogReporter() *LogReporter {
 
 // Report logs the error to the Logger.
 func (h *LogReporter) Report(ctx context.Context, err error) error {
-	switch err := err.(type) {
-	case *Error:
-		var line *BacktraceLine
+	var file, line string
+	var stack errors.StackTrace
 
-		if len(err.Backtrace) > 0 {
-			line = err.Backtrace[0]
-		} else {
-			line = &BacktraceLine{
-				File: "unknown",
-				Line: 0,
-			}
-		}
-
-		logger.Error(ctx, "", "error", fmt.Sprintf(`"%v"`, err), "line", line.Line, "file", line.File)
-	default:
-		logger.Error(ctx, "", "error", fmt.Sprintf(`"%v"`, err))
+	if err_with_stack, ok := err.(stackTracer); ok {
+		stack = err_with_stack.StackTrace()
+	}
+	if stack != nil && len(stack) > 0 {
+		file = fmt.Sprintf("%s", stack[0])
+		line = fmt.Sprintf("%d", stack[0])
+	} else {
+		file = "unknown"
+		line = "0"
 	}
 
+	logger.Error(ctx, "", "error", fmt.Sprintf(`"%v"`, err), "line", line, "file", file)
 	return nil
 }

--- a/reporter/logger_test.go
+++ b/reporter/logger_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/remind101/pkg/logger"
 	"golang.org/x/net/context"
 )
@@ -14,9 +15,9 @@ func TestLogReporter(t *testing.T) {
 		err error
 		out string
 	}{
-		{errBoom, "request_id=1234  error=\"boom\"\n"},
+		{errBoom, "request_id=1234  error=\"boom\" line=0 file=unknown\n"},
 		{&Error{Err: errBoom}, "request_id=1234  error=\"boom\" line=0 file=unknown\n"},
-		{&Error{Err: errBoom, Backtrace: []*BacktraceLine{&BacktraceLine{File: "foo.go", Line: 1}}}, "request_id=1234  error=\"boom\" line=1 file=foo.go\n"},
+		{NewError(errors.Wrap(errBoom, "this is a wrap"), 0), "request_id=1234  error=\"this is a wrap: boom\" line=20 file=logger_test.go\n"},
 	}
 
 	for i, tt := range tests {

--- a/reporter/logger_test.go
+++ b/reporter/logger_test.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/remind101/pkg/logger"
 	"golang.org/x/net/context"
 )
@@ -17,7 +16,7 @@ func TestLogReporter(t *testing.T) {
 	}{
 		{errBoom, "request_id=1234  error=\"boom\" line=0 file=unknown\n"},
 		{&Error{Err: errBoom}, "request_id=1234  error=\"boom\" line=0 file=unknown\n"},
-		{NewError(errors.Wrap(errBoom, "this is a wrap"), 0), "request_id=1234  error=\"this is a wrap: boom\" line=20 file=logger_test.go\n"},
+		{NewError(errBoom, 0), "request_id=1234  error=\"boom\" line=19 file=logger_test.go\n"},
 	}
 
 	for i, tt := range tests {

--- a/reporter/nr/nr.go
+++ b/reporter/nr/nr.go
@@ -35,8 +35,8 @@ func (r *Reporter) Report(ctx context.Context, err error) error {
 		if e, ok := err.(*reporter.Error); ok {
 			exceptionType = util.ClassName(e.Err)
 
-			for _, l := range e.Backtrace {
-				stackTrace = append(stackTrace, fmt.Sprintf("%s:%d %s", l.File, l.Line, util.FunctionName(l.PC)))
+			for _, frame := range e.StackTrace() {
+				stackTrace = append(stackTrace, fmt.Sprintf("%s:%d %n", frame, frame, frame))
 			}
 
 		}

--- a/reporter/nr/nr_test.go
+++ b/reporter/nr/nr_test.go
@@ -1,9 +1,9 @@
 package nr
 
 import (
-	"errors"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/remind101/newrelic"
 	"github.com/remind101/pkg/reporter"
 	"golang.org/x/net/context"
@@ -21,7 +21,7 @@ func TestReport(t *testing.T) {
 	tx := newrelic.NewTx("GET /boom")
 	tx.Reporter = &TestReporter{
 		f: func(id int64, exceptionType, errorMessage, stackTrace, stackFrameDelim string) {
-			if got, want := exceptionType, "*errors.errorString"; got != want {
+			if got, want := exceptionType, "*errors.fundamental"; got != want {
 				t.Errorf("exceptionType => %v; want %v", got, want)
 			}
 			if got, want := errorMessage, "boom"; got != want {

--- a/reporter/nr/nr_test.go
+++ b/reporter/nr/nr_test.go
@@ -1,9 +1,9 @@
 package nr
 
 import (
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/remind101/newrelic"
 	"github.com/remind101/pkg/reporter"
 	"golang.org/x/net/context"
@@ -21,7 +21,7 @@ func TestReport(t *testing.T) {
 	tx := newrelic.NewTx("GET /boom")
 	tx.Reporter = &TestReporter{
 		f: func(id int64, exceptionType, errorMessage, stackTrace, stackFrameDelim string) {
-			if got, want := exceptionType, "*errors.fundamental"; got != want {
+			if got, want := exceptionType, "*errors.errorString"; got != want {
 				t.Errorf("exceptionType => %v; want %v", got, want)
 			}
 			if got, want := errorMessage, "boom"; got != want {

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -116,7 +116,7 @@ type Error struct {
 
 	// This is private so that it can be exposed via StackTrace(),
 	// which implements the stackTracker interface.
-	stackTrace *errors.StackTrace
+	stackTrace errors.StackTrace
 }
 
 // Make Error implement the error interface.
@@ -131,10 +131,7 @@ func (e *Error) Cause() error {
 
 // Make Error implement the stackTracer interface.
 func (e *Error) StackTrace() errors.StackTrace {
-	if e.stackTrace != nil {
-		return *e.stackTrace
-	}
-	return nil
+	return e.stackTrace
 }
 
 // NewError wraps err as an Error and generates a stack trace pointing at the
@@ -180,9 +177,9 @@ type stackTracer interface {
 	StackTrace() errors.StackTrace
 }
 
-// It generates a brand new stack trace
-// If it's in the middle of recovering from a panic call,
-// it reindexes starting at the
+// It generates a brand new stack trace given an error and
+// the number of frames that should be skipped,
+// from innermost to outermost frames.
 func gen_stacktrace(err error, skip int) errors.StackTrace {
 	var stack errors.StackTrace
 	err_with_stack := errors.WithStack(err)
@@ -231,7 +228,7 @@ func get_stacktrace(err error) errors.StackTrace {
 	return stack
 }
 
-func stacktrace(err error, skip int) *errors.StackTrace {
+func stacktrace(err error, skip int) errors.StackTrace {
 	stack := get_stacktrace(err)
 	if stack == nil {
 		stack = gen_stacktrace(err, skip+1)
@@ -239,7 +236,7 @@ func stacktrace(err error, skip int) *errors.StackTrace {
 	if len(stack) > DefaultMax {
 		stack = stack[:DefaultMax]
 	}
-	return &stack
+	return stack
 }
 
 // info is used internally to store contextual information. Any empty info

--- a/reporter/reporter_test.go
+++ b/reporter/reporter_test.go
@@ -2,9 +2,8 @@ package reporter
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
-	"path"
-	"runtime"
 	"testing"
 
 	"golang.org/x/net/context"
@@ -20,11 +19,15 @@ func TestReport(t *testing.T) {
 			t.Fatal("request information not set")
 		}
 
-		line := e.Backtrace[0]
-		fn := runtime.FuncForPC(line.PC)
+		stack := e.StackTrace()
+		var method string
+		if stack != nil && len(stack) > 0 {
+			method = fmt.Sprintf("%n", stack[0])
+		}
 
-		if got, want := path.Base(fn.Name()), "reporter.TestReport"; got != want {
-			t.Fatalf("expected the first backtrace line to be this function")
+		if got, want := method, "reporter.TestReport"; got != want {
+			//TODO(danilo): fix this test once a default stack trace is generated
+			//t.Fatalf("expected the first backtrace line to be this function")
 		}
 
 		return nil

--- a/reporter/reporter_test.go
+++ b/reporter/reporter_test.go
@@ -25,9 +25,8 @@ func TestReport(t *testing.T) {
 			method = fmt.Sprintf("%n", stack[0])
 		}
 
-		if got, want := method, "reporter.TestReport"; got != want {
-			//TODO(danilo): fix this test once a default stack trace is generated
-			//t.Fatalf("expected the first backtrace line to be this function")
+		if got, want := method, "TestReport"; got != want {
+			t.Fatalf("expected the first stacktrace method to be %v, got %v", want, got)
 		}
 
 		return nil


### PR DESCRIPTION
This is a proposal for raising/handling errors in Go, inspired by https://dave.cheney.net/2016/04/27/dont-just-check-errors-handle-them-gracefully.

## What changes for callers?

First, import [github.com/pkg/errors](https://godoc.org/github.com/pkg/errors).

### When raising errors

```
# before
panic("boom")

# after - this will capture the right stack trace
panic(errors.New("boom"))
```

### When raising typed errors (it aggregates better in honeybadger)

```
type CustomError string

func (e CustomError) Error() string {
  return string(e)
}

# before
panic(CustomError("boom"))

# after - this will capture the right stack trace
panic(errors.WithStack(CustomError("boom")))
```

### When calling a function that may return an error

```
func DoSomething() string, error {...}

result, err := DoSomething()

# before
if err != nil {
  return nil, err
}

# before
if err != nil {
  return nil, fmt.Errorf("error while calling DoSomething: %v", err)
}

# after - this will capture the right stack trace + root cause
if err != nil {
  return nil, errors.Wrap(err, "error while calling DoSomething")
}
```

## Changes


`reporter/reporter.go`:

* remove custom Backtrace type, use `errors.StackTrace` instead from [github.com/pkg/errors](https://godoc.org/github.com/pkg/errors)
* modified code that generates stack trace so that it returns an instance of errors.StackTrace and it exposes existing stack trace info in errors that implement `stackTracer`

`reporter/logger.go`:

* simplified code in order to handle the standard errors.StackTrace type

`reporter/hb2/hb2.go`:

* added code to translate `errors.StackTrace` instances into the format required by Honeybadger.
* honeybadger errors are created by instantiating `honeybadger.Error` directly so that the stack trace can be injected from above.

There is remaining work captured with `TODO`s in the code.