### PR TITLE
Add support for temporary and timeout errors

### DIFF
--- a/httpx/middleware/error.go
+++ b/httpx/middleware/error.go
@@ -19,27 +19,40 @@ type timeoutError interface {
 	Timeout() bool // Is the error a timeout?
 }
 
+type statusCoder interface {
+	StatusCode() int
+}
+
 // DefaultErrorHandler is an error handler that will respond with the error
 // message and a 500 status.
 var DefaultErrorHandler = func(ctx context.Context, err error, w http.ResponseWriter, r *http.Request) {
-	status := http.StatusInternalServerError
-
-	if e, ok := err.(temporaryError); ok && e.Temporary() {
-		status = http.StatusServiceUnavailable
-	}
-
-	if e, ok := err.(timeoutError); ok && e.Timeout() {
-		status = http.StatusServiceUnavailable
-	}
-
-	http.Error(w, err.Error(), status)
+	writeError(w, err)
 }
 
 // ReportingErrorHandler is an error handler that will report the error and respond
 // with the error message and a 500 status.
 var ReportingErrorHandler = func(ctx context.Context, err error, w http.ResponseWriter, r *http.Request) {
 	reporter.Report(ctx, err)
-	http.Error(w, err.Error(), http.StatusInternalServerError)
+	writeError(w, err)
+}
+
+func writeError(w http.ResponseWriter, err error) {
+	http.Error(w, err.Error(), statusCodeForError(err))
+}
+
+func statusCodeForError(err error) int {
+	if e, ok := err.(statusCoder); ok {
+		return e.StatusCode()
+	}
+	if e, ok := err.(temporaryError); ok && e.Temporary() {
+		return http.StatusServiceUnavailable
+	}
+
+	if e, ok := err.(timeoutError); ok && e.Timeout() {
+		return http.StatusServiceUnavailable
+	}
+
+	return http.StatusInternalServerError
 }
 
 // Error is an httpx.Handler that will handle errors with an ErrorHandler.

--- a/httpx/middleware/error_test.go
+++ b/httpx/middleware/error_test.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -48,6 +49,11 @@ func TestErrorMiddleware(t *testing.T) {
 		{
 			Error: tmpError("service unavailable"),
 			Body:  "service unavailable\n",
+			Code:  503,
+		},
+		{
+			Error: &net.DNSError{Err: "no such host", IsTimeout: true},
+			Body:  "lookup : no such host\n",
 			Code:  503,
 		},
 		{


### PR DESCRIPTION
This gives the default error handler middleware awareness of temporary errors. It'l respond with a 503 if it can detect the error is temporary.