### PR TITLE
Report error cause to rollbar

### DIFF
--- a/reporter/rollbar/rollbar.go
+++ b/reporter/rollbar/rollbar.go
@@ -39,6 +39,7 @@ func (r *rollbarReporter) Report(ctx context.Context, err error) error {
 		}
 
 		stackTrace = makeRollbarStack(e.StackTrace())
+		err = e.Cause() // Report the actual cause of the error.
 	}
 
 	reportToRollbar(request, err, stackTrace, extraFields)


### PR DESCRIPTION
Previously, this would pass a `reporter.Error` through to the rollbar package, so the error class would always show `reporter.Error` in rollbar.