### PR TITLE
ReportWithLevel: allows callers to specify which report level they want

### DIFF
--- a/httpx/middleware/recovery_test.go
+++ b/httpx/middleware/recovery_test.go
@@ -18,7 +18,7 @@ func TestRecovery(t *testing.T) {
 	)
 
 	h := &Recovery{
-		Reporter: reporter.ReporterFunc(func(ctx context.Context, err error) error {
+		Reporter: reporter.ReporterFunc(func(ctx context.Context, level string, err error) error {
 			called = true
 
 			e := err.(*reporter.Error)
@@ -59,7 +59,7 @@ func TestRecovery(t *testing.T) {
 
 func TestRecoveryPanicString(t *testing.T) {
 	h := &Recovery{
-		Reporter: reporter.ReporterFunc(func(ctx context.Context, err error) error {
+		Reporter: reporter.ReporterFunc(func(ctx context.Context, level string, err error) error {
 			return nil
 		}),
 		handler: httpx.HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {

--- a/reporter/fallback.go
+++ b/reporter/fallback.go
@@ -11,9 +11,9 @@ type FallbackReporter struct {
 	Fallback Reporter
 }
 
-func (r *FallbackReporter) Report(ctx context.Context, err error) error {
-	if err2 := r.Reporter.Report(ctx, err); err2 != nil {
-		r.Fallback.Report(ctx, err2)
+func (r *FallbackReporter) ReportWithLevel(ctx context.Context, level string, err error) error {
+	if err2 := r.Reporter.ReportWithLevel(ctx, level, err); err2 != nil {
+		r.Fallback.ReportWithLevel(ctx, level, err2)
 		return err2
 	}
 

--- a/reporter/fallback_test.go
+++ b/reporter/fallback_test.go
@@ -13,10 +13,10 @@ func TestFallback(t *testing.T) {
 	errTimeout := errors.New("net: timeout")
 
 	r := &FallbackReporter{
-		Reporter: ReporterFunc(func(ctx context.Context, err error) error {
+		Reporter: ReporterFunc(func(ctx context.Context, level string, err error) error {
 			return errTimeout
 		}),
-		Fallback: ReporterFunc(func(ctx context.Context, err error) error {
+		Fallback: ReporterFunc(func(ctx context.Context, level string, err error) error {
 			called = true
 
 			if got, want := err, errTimeout; got != want {
@@ -27,7 +27,8 @@ func TestFallback(t *testing.T) {
 		}),
 	}
 
-	r.Report(context.Background(), errBoom)
+	ctx := WithReporter(context.Background(), r)
+	Report(ctx, errBoom)
 
 	if !called {
 		t.Fatal("fallback not called")

--- a/reporter/hb2/hb2.go
+++ b/reporter/hb2/hb2.go
@@ -68,7 +68,7 @@ func makeHoneybadgerError(err *reporter.Error) honeybadger.Error {
 }
 
 // Report reports the error to honeybadger.
-func (r *HbReporter) Report(ctx context.Context, err error) error {
+func (r *HbReporter) ReportWithLevel(ctx context.Context, level string, err error) error {
 	extras := []interface{}{}
 
 	if e, ok := err.(*reporter.Error); ok {

--- a/reporter/hb2/hb2_test.go
+++ b/reporter/hb2/hb2_test.go
@@ -85,7 +85,8 @@ func TestHb2ReportsErrorContext(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		r.Report(context.Background(), tt.err)
+		ctx := reporter.WithReporter(context.Background(), r)
+		reporter.Report(ctx, tt.err)
 
 		select {
 		case v := <-h.LastRequestBodyChan:

--- a/reporter/logger.go
+++ b/reporter/logger.go
@@ -16,7 +16,7 @@ func NewLogReporter() *LogReporter {
 }
 
 // Report logs the error to the Logger.
-func (h *LogReporter) Report(ctx context.Context, err error) error {
+func (h *LogReporter) ReportWithLevel(ctx context.Context, level string, err error) error {
 	var file, line string
 	var stack errors.StackTrace
 
@@ -31,6 +31,12 @@ func (h *LogReporter) Report(ctx context.Context, err error) error {
 		line = "0"
 	}
 
-	logger.Error(ctx, "", "error", fmt.Sprintf(`"%v"`, err), "line", line, "file", file)
+	if level == "debug" {
+		logger.Debug(ctx, "", "debug", fmt.Sprintf(`"%v"`, err), "line", line, "file", file)
+	} else if level == "info" {
+		logger.Info(ctx, "", "info", fmt.Sprintf(`"%v"`, err), "line", line, "file", file)
+	} else {
+		logger.Error(ctx, "", level, fmt.Sprintf(`"%v"`, err), "line", line, "file", file)
+	}
 	return nil
 }

--- a/reporter/logger_test.go
+++ b/reporter/logger_test.go
@@ -25,7 +25,7 @@ func TestLogReporter(t *testing.T) {
 		h := &LogReporter{}
 
 		ctx := logger.WithLogger(context.Background(), l)
-		if err := h.Report(ctx, tt.err); err != nil {
+		if err := h.ReportWithLevel(ctx, "error", tt.err); err != nil {
 			t.Fatal(err)
 		}
 

--- a/reporter/multi.go
+++ b/reporter/multi.go
@@ -7,11 +7,11 @@ import "golang.org/x/net/context"
 // an error, a MutliError will be returned.
 type MultiReporter []Reporter
 
-func (r MultiReporter) Report(ctx context.Context, err error) error {
+func (r MultiReporter) ReportWithLevel(ctx context.Context, level string, err error) error {
 	var errors []error
 
 	for _, reporter := range r {
-		if err2 := reporter.Report(ctx, err); err2 != nil {
+		if err2 := reporter.ReportWithLevel(ctx, level, err); err2 != nil {
 			errors = append(errors, err2)
 		}
 	}

--- a/reporter/multi_test.go
+++ b/reporter/multi_test.go
@@ -13,19 +13,20 @@ func TestMultiReporter(t *testing.T) {
 		r2Called bool
 	)
 
-	r1 := ReporterFunc(func(ctx context.Context, err error) error {
+	r1 := ReporterFunc(func(ctx context.Context, level string, err error) error {
 		r1Called = true
 		return nil
 	})
 
-	r2 := ReporterFunc(func(ctx context.Context, err error) error {
+	r2 := ReporterFunc(func(ctx context.Context, level string, err error) error {
 		r2Called = true
 		return nil
 	})
 
 	h := MultiReporter{r1, r2}
+	ctx := WithReporter(context.Background(), h)
 
-	if err := h.Report(context.Background(), errBoom); err != nil {
+	if err := Report(ctx, errBoom); err != nil {
 		t.Fatal(err)
 	}
 
@@ -40,17 +41,18 @@ func TestMultiReporter(t *testing.T) {
 
 // Tests when the Report method of the individual reporters returns an error.
 func TestMultiReporterError(t *testing.T) {
-	r1 := ReporterFunc(func(ctx context.Context, err error) error {
+	r1 := ReporterFunc(func(ctx context.Context, level string, err error) error {
 		return errors.New("boom 1")
 	})
 
-	r2 := ReporterFunc(func(ctx context.Context, err error) error {
+	r2 := ReporterFunc(func(ctx context.Context, level string, err error) error {
 		return errors.New("boom 2")
 	})
 
 	h := MultiReporter{r1, r2}
 
-	err := h.Report(context.Background(), errBoom)
+	ctx := WithReporter(context.Background(), h)
+	err := Report(ctx, errBoom)
 
 	if _, ok := err.(*MultiError); !ok {
 		t.Fatal("Expected a MultiError to be returned")

--- a/reporter/nr/nr.go
+++ b/reporter/nr/nr.go
@@ -19,7 +19,7 @@ func NewReporter() *Reporter {
 	return &Reporter{}
 }
 
-func (r *Reporter) Report(ctx context.Context, err error) error {
+func (r *Reporter) ReportWithLevel(ctx context.Context, level string, err error) error {
 	if tx, ok := newrelic.FromContext(ctx); ok {
 		var (
 			exceptionType   string

--- a/reporter/nr/nr_test.go
+++ b/reporter/nr/nr_test.go
@@ -36,9 +36,8 @@ func TestReport(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = newrelic.WithTx(ctx, tx)
-
-	r := NewReporter()
-	r.Report(ctx, errBoomMore)
+	ctx = reporter.WithReporter(ctx, NewReporter())
+	reporter.Report(ctx, errBoomMore)
 }
 
 type TestReporter struct {

--- a/reporter/rollbar/rollbar.go
+++ b/reporter/rollbar/rollbar.go
@@ -26,7 +26,7 @@ func ConfigureReporter(token, environment string) {
 	rollbar.Environment = environment
 }
 
-func (r *rollbarReporter) Report(ctx context.Context, err error) error {
+func (r *rollbarReporter) ReportWithLevel(ctx context.Context, level string, err error) error {
 	var request *http.Request
 	extraFields := []*rollbar.Field{}
 	var stackTrace rollbar.Stack = nil
@@ -42,22 +42,22 @@ func (r *rollbarReporter) Report(ctx context.Context, err error) error {
 		err = e.Cause() // Report the actual cause of the error.
 	}
 
-	reportToRollbar(request, err, stackTrace, extraFields)
+	reportToRollbar(level, request, err, stackTrace, extraFields)
 	return nil
 }
 
-func reportToRollbar(request *http.Request, err error, stack rollbar.Stack, extraFields []*rollbar.Field) {
+func reportToRollbar(level string, request *http.Request, err error, stack rollbar.Stack, extraFields []*rollbar.Field) {
 	if request != nil {
 		if stack != nil {
-			rollbar.RequestErrorWithStack(ErrorLevel, request, err, stack, extraFields...)
+			rollbar.RequestErrorWithStack(level, request, err, stack, extraFields...)
 		} else {
-			rollbar.RequestError(ErrorLevel, request, err, extraFields...)
+			rollbar.RequestError(level, request, err, extraFields...)
 		}
 	} else {
 		if stack != nil {
-			rollbar.ErrorWithStack(ErrorLevel, err, stack, extraFields...)
+			rollbar.ErrorWithStack(level, err, stack, extraFields...)
 		} else {
-			rollbar.Error(ErrorLevel, err, extraFields...)
+			rollbar.Error(level, err, extraFields...)
 		}
 	}
 }

--- a/reporter/rollbar/rollbar_test.go
+++ b/reporter/rollbar/rollbar_test.go
@@ -47,7 +47,8 @@ func TestReportsThingsToRollbar(t *testing.T) {
 	ConfigureReporter("token", "test")
 	rollbar.Endpoint = ts.URL + "/"
 	fmt.Println(ts.URL)
-	Reporter.Report(context.Background(), err)
+	ctx := reporter.WithReporter(context.Background(), Reporter)
+	reporter.Report(ctx, err)
 	rollbar.Wait()
 
 	paramValue := body["data"].(map[string]interface{})["request"].(map[string]interface{})["POST"].(map[string]interface{})["param1"]


### PR DESCRIPTION
This can be a breaking change, but hopefully it won't affect existing code that relies on `reporter.Report(context.Context, error) error` to report error messages to third-party reporters, like rollbar/honeybadger/newrelic.

In addition to the existing `reporter.Report` interface, it adds:

```
ReportWithLevel(context.Context, string, error) error
```

Which lets callers specify which level they want for their message. It is currently a string field so that individual third-party services can decide to convert it to a special type if they need to. Rollbar uses simple strings, for instance.

### Backwards compatibility

This pull request also fixes all existing `Reporter` implementations to use the new API internally. Therefore, this should only be a problem for callers who are dealing with `Reporter` instances rather than the `reporter.Report` package-level function. We could provide a backwards compatible interface to maintain the existing `Report` function in a `Reporter` type, however, I'd like not to have to support both to keep that API slim, unless it would break many existing clients.