### PR TITLE
Add SSM as storage option for request signing keys

### DIFF
--- a/httpx/middleware/reqsigssm/request_signing_ssm.go
+++ b/httpx/middleware/reqsigssm/request_signing_ssm.go
@@ -1,0 +1,27 @@
+package reqsigssm
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/remind101/pkg/httpx/middleware"
+)
+
+// NewWithPath takes a path, and returns an instance of
+// middleware.StaticSigningKeyRepository initialized with client keys / secrets
+// fetched from the given path. The assumption is that path points to an SSM
+// directory containing the client keys and secrets.
+func NewWithPath(path string) (*middleware.StaticSigningKeyRepository, error) {
+	kmap := map[string]string{}
+	sess := session.Must(session.NewSession())
+	svc := ssm.New(sess)
+
+	err := svc.GetParametersByPathPages(path, func(out *ssm.GetParametersByPathOutput, cont bool) bool {
+		for _, param := range out.Parameters {
+			kmap[*param.Name] = *param.Value
+		}
+		return true
+	})
+	r := middleware.NewStaticSigningKeyRepository(kmap)
+
+	return r, err
+}

--- a/httpx/middleware/reqsigssm/request_signing_ssm.go
+++ b/httpx/middleware/reqsigssm/request_signing_ssm.go
@@ -1,6 +1,7 @@
 package reqsigssm
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/remind101/pkg/httpx/middleware"
@@ -14,10 +15,14 @@ func NewWithPath(path string) (*middleware.StaticSigningKeyRepository, error) {
 	kmap := map[string]string{}
 	sess := session.Must(session.NewSession())
 	svc := ssm.New(sess)
+	in := &ssm.GetParametersByPathInput{
+		Path:           aws.String(path),
+		WithDecryption: aws.Bool(true),
+	}
 
-	err := svc.GetParametersByPathPages(path, func(out *ssm.GetParametersByPathOutput, cont bool) bool {
+	err := svc.GetParametersByPathPages(in, func(out *ssm.GetParametersByPathOutput, cont bool) bool {
 		for _, param := range out.Parameters {
-			kmap[*param.Name] = *param.Value
+			kmap[aws.StringValue(param.Name)] = aws.StringValue(param.Value)
 		}
 		return true
 	})


### PR DESCRIPTION
I'll be sure to test this in a repo first.