### PR TITLE
Hide sensitive data in the Reporter interface

### DIFF
--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -5,6 +5,7 @@ package reporter
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -55,8 +56,97 @@ func AddContext(ctx context.Context, key string, value interface{}) {
 // AddRequest adds information from an http.Request to the Request object.
 func AddRequest(ctx context.Context, req *http.Request) {
 	i := infoFromContext(ctx)
-	// TODO clone the request?
-	i.request = req
+	i.request = safeCloneRequest(req)
+}
+
+func safeCloneRequest(req *http.Request) *http.Request {
+	return &http.Request{
+		Method:     req.Method,
+		URL:        safeCloneURL(req.URL),
+		Proto:      req.Proto,
+		ProtoMajor: req.ProtoMajor,
+		ProtoMinor: req.ProtoMinor,
+		Header:     *safeCloneHeader(&req.Header),
+		// Body may have sensitive information,
+		// besides all the data should be already parsed as Form and/or PostForm
+		Body:             nil,
+		ContentLength:    req.ContentLength,
+		TransferEncoding: copyStringArray(req.TransferEncoding),
+		Close:            req.Close,
+		Host:             req.Host,
+		Form:             *safeCloneForm(&req.Form),
+		PostForm:         *safeCloneForm(&req.PostForm),
+		// MultipartForm may have sensitive information
+		MultipartForm: nil,
+		// Trailer isn't that important for reporting purposes
+		Trailer:    nil,
+		RemoteAddr: req.RemoteAddr,
+		RequestURI: req.RequestURI,
+	}
+}
+
+func safeCloneURL(u *url.URL) *url.URL {
+	if u == nil {
+		return nil
+	}
+	return &url.URL{
+		Scheme: u.Scheme,
+		// req.User may have sensitive information, like username and password
+		Host:       u.Host,
+		Path:       u.Path,
+		RawPath:    u.RawPath,
+		ForceQuery: u.ForceQuery,
+		RawQuery:   u.RawQuery,
+		Fragment:   u.Fragment,
+	}
+}
+
+var sensitiveHeaders = map[string]bool{
+	"Authorization": true,
+	"Cookie":        true,
+}
+
+func safeCloneHeader(header *http.Header) *http.Header {
+	if header == nil {
+		return nil
+	}
+	safeHeader := http.Header{}
+	for key, valueArray := range *header {
+		if _, ok := sensitiveHeaders[key]; ok {
+			continue
+		}
+		safeHeader[key] = copyStringArray(valueArray)
+	}
+	return &safeHeader
+}
+
+func copyStringArray(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	safeArray := make([]string, len(values))
+	for idx, value := range values {
+		safeArray[idx] = value
+	}
+	return safeArray
+}
+
+var sensitiveFormKeys = map[string]bool{
+	"password": true,
+}
+
+func safeCloneForm(form *url.Values) *url.Values {
+	if form == nil {
+		return nil
+	}
+	safeForm := url.Values{}
+	for key, values := range *form {
+		if _, ok := sensitiveFormKeys[key]; ok {
+			continue
+		}
+		safeForm[key] = copyStringArray(values)
+	}
+	return &safeForm
 }
 
 // newError returns a new Error instance. If err is already an Error instance,

--- a/reporter/reporter_test.go
+++ b/reporter/reporter_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"golang.org/x/net/context"
@@ -69,6 +70,90 @@ func TestReportWithNoReporterInContext(t *testing.T) {
 	}()
 	ctx := context.Background() // no reporter
 	Report(ctx, errBoom)
+}
+
+func TestReportWithSensitiveData(t *testing.T) {
+	r := ReporterFunc(func(ctx context.Context, level string, err error) error {
+		e := err.(*Error)
+
+		if e.Request.URL.Scheme != "http" {
+			t.Fatalf("expected request.URL.Scheme to be \"http\", got: %v", e.Request.URL.Scheme)
+		}
+
+		if e.Request.URL.User != nil {
+			t.Fatal("expected request.User to have been removed by the reporter")
+		}
+
+		if e.Request.URL.Host != "remind.com:80" {
+			t.Fatalf("expected request.URL.Host to be \"remind.com:80\", got: %v", e.Request.URL.Host)
+		}
+
+		if e.Request.URL.Path != "/docs" {
+			t.Fatalf("expected request.URL.Host to be \"/docs\", got: %v", e.Request.URL.Path)
+		}
+
+		if e.Request.Header.Get("Content-Type") != "application/json" {
+			t.Fatalf("expected request.Header[\"Content-type\"] to be \"application/json\", got: %v", e.Request.Header.Get("Content-Type"))
+		}
+
+		if e.Request.Header.Get("Authorization") != "" {
+			t.Fatal("expected request.headers.Authorization to have been removed by the reporter")
+		}
+
+		if e.Request.Header.Get("Cookie") != "" {
+			t.Fatal("expected request.headers.Cookie to have been removed by the reporter")
+		}
+
+		if len(e.Request.Cookies()) != 0 {
+			t.Fatal("expected request.Cookies to have been removed by the reporter")
+		}
+
+		return nil
+	})
+
+	ctx := WithReporter(context.Background(), r)
+	req, _ := http.NewRequest("GET", "http://user:pass@remind.com:80/docs", nil)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "this-is-a-secret")
+	req.Header.Set("Cookie", "r101_auth_token=this-is-sensitive")
+	AddRequest(ctx, req)
+
+	if err := ReportWithLevel(ctx, "error", errBoom); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReportWithFormData(t *testing.T) {
+	r := ReporterFunc(func(ctx context.Context, level string, err error) error {
+		e := err.(*Error)
+
+		if e.Request.Form.Get("key") != "foo" {
+			t.Fatalf("expected request.Form[\"key\"] to be \"foo\", got: %v", e.Request.Form.Get("key"))
+		}
+
+		if e.Request.Form.Get("username") != "admin" {
+			t.Fatalf("expected request.Form[\"username\"] to be \"admin\", got: %v", e.Request.Form.Get("username"))
+		}
+
+		if e.Request.Form.Get("password") != "" {
+			t.Fatal("expected request.Form[\"password\"] to have been removed by the reporter")
+		}
+
+		return nil
+	})
+	ctx := WithReporter(context.Background(), r)
+
+	req, _ := http.NewRequest("POST", "/", nil)
+	req.Header.Set("Content-Type", "application/json")
+	req.Form = url.Values{}
+	req.Form.Add("key", "foo")
+	req.Form.Add("username", "admin")
+	req.Form.Add("password", "this-is-a-secret")
+	AddRequest(ctx, req)
+
+	if err := ReportWithLevel(ctx, "error", errBoom); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestMonitor(t *testing.T) {


### PR DESCRIPTION
Our `Reporter` interface is leaking sensitive data to third-party services, like Rollbar. Let's avoid that by cloning the request at the top-level so that there is 0 chance of that happening after a request has been set in a `Reporter` context.

For instance: https://rollbar.com/Remind/r101-permissions/items/6/occurrences/34616600793/