### PR TITLE
Native context

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [remind101/pkg](https://github.com/remind101/pkg) [![Build Status](https://travis-ci.org/remind101/pkg.svg?branch=master)](https://travis-ci.org/remind101/pkg) [![GoDoc](https://godoc.org/github.com/remind101/pkg?status.svg)](https://godoc.org/github.com/remind101/pkg)
 
-package pkg is a collection of Go packages that provide a layer of convenience over the stdlib and primarily adds **[context.Context](https://godoc.org/golang.org/x/net/context)** awareness, making it easier to do things like distributed request tracing.
+package pkg is a collection of Go packages that provide a layer of convenience over the stdlib and primarily adds **[context.Context](https://godoc.org/context)** awareness, making it easier to do things like distributed request tracing.
 
 ## Packages
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [remind101/pkg](https://github.com/remind101/pkg) [![Build Status](https://travis-ci.org/remind101/pkg.svg?branch=master)](https://travis-ci.org/remind101/pkg) [![GoDoc](https://godoc.org/github.com/remind101/pkg?status.svg)](https://godoc.org/github.com/remind101/pkg)
 
-package pkg is a collection of Go packages that provide a layer of convenience over the stdlib and primarily adds **[context.Context](https://godoc.org/context)** awareness, making it easier to do things like distributed request tracing.
+package pkg is a collection of Go packages that provide a layer of convenience over the stdlib.
 
 ## Packages
 

--- a/example/main.go
+++ b/example/main.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/pkg/errors"
 
+	"context"
+
 	"github.com/remind101/pkg/httpx"
 	"github.com/remind101/pkg/httpx/middleware"
 	"github.com/remind101/pkg/logger"
 	"github.com/remind101/pkg/reporter"
 	"github.com/remind101/pkg/retry"
-	"golang.org/x/net/context"
 )
 
 func ok(ctx context.Context, w http.ResponseWriter, r *http.Request) error {

--- a/httpx/README.md
+++ b/httpx/README.md
@@ -2,7 +2,7 @@
 
 Package httpx provides a layer of convenience over "net/http". Specifically:
 
-1. It's **[context.Context](https://godoc.org/golang.org/x/net/context)** aware.
+1. It's **[context.Context](https://godoc.org/context)** aware.
    This is good for storing request specific parameters, such as a request ids
    and for performing deadlines and cancellations across api boundaries in a
    generic way.

--- a/httpx/README.md
+++ b/httpx/README.md
@@ -2,11 +2,7 @@
 
 Package httpx provides a layer of convenience over "net/http". Specifically:
 
-1. It's **[context.Context](https://godoc.org/context)** aware.
-   This is good for storing request specific parameters, such as a request ids
-   and for performing deadlines and cancellations across api boundaries in a
-   generic way.
-2. `httpx.Handler`'s return an `error` which makes handler implementations feel
+1. `httpx.Handler`'s return an `error` which makes handler implementations feel
    more idiomatic and reduces the chance of accidentally forgetting to return.
 
 The most important part of package httpx is the `Handler` interface, which is
@@ -20,7 +16,7 @@ type Handler interface {
 
 ## Usage
 
-In order to use the `httpx.Handler` interface, you need a compatible router. One is provided within this package that wraps [gorilla mux](https://github.com/gorilla/mux) to make it context.Context aware.
+In order to use the `httpx.Handler` interface, you need a compatible router. One is provided within this package that wraps [gorilla mux](https://github.com/gorilla/mux).
 
 ```go
 r := httpx.NewRouter()

--- a/httpx/http_service.go
+++ b/httpx/http_service.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/remind101/pkg/retry"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 type RoundTripper interface {

--- a/httpx/http_service_test.go
+++ b/httpx/http_service_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 	"github.com/remind101/pkg/retry"
 )
 

--- a/httpx/httpx.go
+++ b/httpx/httpx.go
@@ -4,7 +4,7 @@ package httpx
 import (
 	"net/http"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Handler is represents a Handler that can take a context.Context as the

--- a/httpx/middleware/background.go
+++ b/httpx/middleware/background.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/remind101/pkg/httpx"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // DefaultGenerator is the default context generator. Defaults to just use

--- a/httpx/middleware/background.go
+++ b/httpx/middleware/background.go
@@ -3,22 +3,20 @@ package middleware
 import (
 	"net/http"
 
-	"github.com/remind101/pkg/httpx"
 	"context"
-)
 
-// DefaultGenerator is the default context generator. Defaults to just use
-// context.Background().
-var DefaultGenerator = context.Background
+	"github.com/remind101/pkg/httpx"
+)
 
 // Background is middleware that implements the http.Handler interface to inject
 // an initial context object. Use this as the entry point from an http.Handler
 // server.
+//
+// This middleware is deprecated. There is no need to pass a context.Context
+// to handlers anymore, since a context object is available from the request. Once
+// we update the signature for httpx.Handler to remove the context parameter, this
+// middleware can be removed.
 type Background struct {
-	// Generate will be called to generate a context.Context for the
-	// request.
-	Generate func() context.Context
-
 	// The wrapped httpx.Handler to call down to.
 	handler httpx.Handler
 }
@@ -31,11 +29,7 @@ func BackgroundContext(h httpx.Handler) *Background {
 
 // ServeHTTP implements the http.Handler interface.
 func (h *Background) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx := h.Generate
-	if ctx == nil {
-		ctx = DefaultGenerator
-	}
-	h.ServeHTTPContext(ctx(), w, r)
+	h.ServeHTTPContext(r.Context(), w, r)
 }
 
 func (h *Background) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, r *http.Request) error {

--- a/httpx/middleware/background_test.go
+++ b/httpx/middleware/background_test.go
@@ -6,8 +6,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/remind101/pkg/httpx"
 	"context"
+
+	"github.com/remind101/pkg/httpx"
 )
 
 func TestBackground(t *testing.T) {
@@ -15,6 +16,10 @@ func TestBackground(t *testing.T) {
 		handler: httpx.HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 			if ctx == nil {
 				t.Fatal("Expected a context to be generated")
+			}
+
+			if ctx != r.Context() {
+				t.Fatal("Expected context to be equal to the request context")
 			}
 
 			io.WriteString(w, `Ok`)

--- a/httpx/middleware/background_test.go
+++ b/httpx/middleware/background_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/remind101/pkg/httpx"
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestBackground(t *testing.T) {

--- a/httpx/middleware/basic_auth.go
+++ b/httpx/middleware/basic_auth.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/remind101/pkg/httpx"
-	"golang.org/x/net/context"
+	"context"
 )
 
 type BasicAuther struct {

--- a/httpx/middleware/basic_auth_test.go
+++ b/httpx/middleware/basic_auth_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/remind101/pkg/httpx"
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestBasicAuth(t *testing.T) {

--- a/httpx/middleware/error.go
+++ b/httpx/middleware/error.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/remind101/pkg/httpx"
-	"golang.org/x/net/context"
+	"context"
 )
 
 type ErrorHandlerFunc func(context.Context, error, http.ResponseWriter, *http.Request)

--- a/httpx/middleware/error_test.go
+++ b/httpx/middleware/error_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/remind101/pkg/httpx"
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestError(t *testing.T) {

--- a/httpx/middleware/logger.go
+++ b/httpx/middleware/logger.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/remind101/pkg/httpx"
 	"github.com/remind101/pkg/logger"
-	"golang.org/x/net/context"
+	"context"
 )
 
 type loggerGenerator func(context.Context, *http.Request) logger.Logger

--- a/httpx/middleware/logger_test.go
+++ b/httpx/middleware/logger_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/remind101/pkg/httpx"
 	"github.com/remind101/pkg/logger"
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestLogger(t *testing.T) {

--- a/httpx/middleware/newrelic_tracer.go
+++ b/httpx/middleware/newrelic_tracer.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/remind101/newrelic"
 	"github.com/remind101/pkg/httpx"
-	"golang.org/x/net/context"
+	"context"
 )
 
 type NewRelicTracer struct {

--- a/httpx/middleware/newrelic_tracer_test.go
+++ b/httpx/middleware/newrelic_tracer_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/remind101/newrelic"
 	"github.com/remind101/pkg/httpx"
 	"github.com/stretchr/testify/mock"
-	"golang.org/x/net/context"
+	"context"
 )
 
 type tracerTest struct {

--- a/httpx/middleware/newrelicgo_tracer.go
+++ b/httpx/middleware/newrelicgo_tracer.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/newrelic/go-agent"
 	"github.com/remind101/pkg/httpx"
-	"golang.org/x/net/context"
+	"context"
 )
 
 type NewRelicGoTracer struct {

--- a/httpx/middleware/recovery.go
+++ b/httpx/middleware/recovery.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/remind101/pkg/httpx"
 	"github.com/remind101/pkg/reporter"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Recovery is a middleware that will recover from panics and return the error.

--- a/httpx/middleware/recovery_test.go
+++ b/httpx/middleware/recovery_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/remind101/pkg/httpx"
 	"github.com/remind101/pkg/reporter"
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestRecovery(t *testing.T) {

--- a/httpx/middleware/request_id.go
+++ b/httpx/middleware/request_id.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/remind101/pkg/httpx"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // DefaultRequestIDExtractor is the default function to use to extract a request

--- a/httpx/middleware/request_id_test.go
+++ b/httpx/middleware/request_id_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/remind101/pkg/httpx"
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestRequestID(t *testing.T) {

--- a/httpx/middleware/request_signing.go
+++ b/httpx/middleware/request_signing.go
@@ -8,7 +8,7 @@ import (
 	httpsignatures "github.com/99designs/httpsignatures-go"
 	"github.com/pkg/errors"
 	"github.com/remind101/pkg/httpx"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // RequestSignatureError should be used in your error handling middleware.

--- a/httpx/middleware/request_signing_test.go
+++ b/httpx/middleware/request_signing_test.go
@@ -9,7 +9,7 @@ import (
 
 	httpsignatures "github.com/99designs/httpsignatures-go"
 	"github.com/remind101/pkg/httpx"
-	"golang.org/x/net/context"
+	"context"
 )
 
 type fakeHandler struct {

--- a/httpx/request_id.go
+++ b/httpx/request_id.go
@@ -1,6 +1,6 @@
 package httpx
 
-import "golang.org/x/net/context"
+import "context"
 
 // WithRequestID inserts a RequestID into the context.
 func WithRequestID(ctx context.Context, requestID string) context.Context {

--- a/httpx/router.go
+++ b/httpx/router.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Router is an httpx.Handler router.

--- a/httpx/router.go
+++ b/httpx/router.go
@@ -5,8 +5,9 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/gorilla/mux"
 	"context"
+
+	"github.com/gorilla/mux"
 )
 
 // Router is an httpx.Handler router.

--- a/httpx/router_test.go
+++ b/httpx/router_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 type routerTest struct {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 type Level int

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestLogger(t *testing.T) {

--- a/metrics/metricshttpx/middleware.go
+++ b/metrics/metricshttpx/middleware.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/remind101/pkg/httpx"
 	"github.com/remind101/pkg/httpx/middleware"

--- a/metrics/metricshttpx/middleware_test.go
+++ b/metrics/metricshttpx/middleware_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/remind101/pkg/httpx/middleware"
 	"github.com/remind101/pkg/metrics"
 	"github.com/remind101/pkg/metrics/metricshttpx"
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestMiddlewareReportsResponseTimeMetrics(t *testing.T) {

--- a/reporter/fallback.go
+++ b/reporter/fallback.go
@@ -1,6 +1,6 @@
 package reporter
 
-import "golang.org/x/net/context"
+import "context"
 
 type FallbackReporter struct {
 	// The first reporter to call.

--- a/reporter/fallback_test.go
+++ b/reporter/fallback_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestFallback(t *testing.T) {

--- a/reporter/hb2/hb2.go
+++ b/reporter/hb2/hb2.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/remind101/pkg/reporter"
 	"github.com/remind101/pkg/reporter/hb2/internal/honeybadger-go"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Headers that won't be sent to honeybadger.

--- a/reporter/hb2/hb2_test.go
+++ b/reporter/hb2/hb2_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/remind101/pkg/reporter"
 )

--- a/reporter/logger.go
+++ b/reporter/logger.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/remind101/pkg/logger"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // LogReporter is a Handler that logs the error to a log.Logger.

--- a/reporter/logger_test.go
+++ b/reporter/logger_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/remind101/pkg/logger"
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestLogReporter(t *testing.T) {

--- a/reporter/multi.go
+++ b/reporter/multi.go
@@ -1,6 +1,6 @@
 package reporter
 
-import "golang.org/x/net/context"
+import "context"
 
 // MultiReporter is an implementation of the Reporter interface that reports the
 // error to multiple Reporters. If any of the individual error reporters returns

--- a/reporter/multi_test.go
+++ b/reporter/multi_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestMultiReporter(t *testing.T) {

--- a/reporter/nr/nr.go
+++ b/reporter/nr/nr.go
@@ -7,7 +7,7 @@ import (
 	"github.com/remind101/newrelic"
 	"github.com/remind101/pkg/reporter"
 	"github.com/remind101/pkg/reporter/util"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Ensure that Reporter implements the reporter.Reporter interface.

--- a/reporter/nr/nr_test.go
+++ b/reporter/nr/nr_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/remind101/newrelic"
 	"github.com/remind101/pkg/reporter"
-	"golang.org/x/net/context"
+	"context"
 )
 
 var (

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // DefaultLevel is the default level a Report uses when reporting an error.

--- a/reporter/reporter_test.go
+++ b/reporter/reporter_test.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 var errBoom = errors.New("boom")

--- a/reporter/rollbar/rollbar.go
+++ b/reporter/rollbar/rollbar.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/pkg/errors"
 	"github.com/remind101/pkg/reporter"

--- a/reporter/rollbar/rollbar_test.go
+++ b/reporter/rollbar/rollbar_test.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/remind101/pkg/reporter"
 	"github.com/stvp/rollbar"


### PR DESCRIPTION
* Switches to native context package
* Updates background middleware to use request.Context()

These are small steps towards achieving #41  where we ditch our custom handler interface.
