### PR TITLE
Middleware additions

### DIFF
--- a/httpx/middleware/error.go
+++ b/httpx/middleware/error.go
@@ -3,8 +3,10 @@ package middleware
 import (
 	"net/http"
 
-	"github.com/remind101/pkg/httpx"
 	"context"
+
+	"github.com/remind101/pkg/httpx"
+	"github.com/remind101/pkg/reporter"
 )
 
 type ErrorHandlerFunc func(context.Context, error, http.ResponseWriter, *http.Request)
@@ -12,6 +14,13 @@ type ErrorHandlerFunc func(context.Context, error, http.ResponseWriter, *http.Re
 // DefaultErrorHandler is an error handler that will respond with the error
 // message and a 500 status.
 var DefaultErrorHandler = func(ctx context.Context, err error, w http.ResponseWriter, r *http.Request) {
+	http.Error(w, err.Error(), http.StatusInternalServerError)
+}
+
+// ReportingErrorHandler is an error handler that will report the error and respond
+// with the error message and a 500 status.
+var ReportingErrorHandler = func(ctx context.Context, err error, w http.ResponseWriter, r *http.Request) {
+	reporter.Report(ctx, err)
 	http.Error(w, err.Error(), http.StatusInternalServerError)
 }
 

--- a/httpx/middleware/logger.go
+++ b/httpx/middleware/logger.go
@@ -8,12 +8,17 @@ import (
 	"os"
 	"time"
 
+	"context"
+
 	"github.com/remind101/pkg/httpx"
 	"github.com/remind101/pkg/logger"
-	"context"
 )
 
 type loggerGenerator func(context.Context, *http.Request) logger.Logger
+
+func LoggerWithRequestID(ctx context.Context, r *http.Request) logger.Logger {
+	return logger.DefaultLogger.With("request_id", httpx.RequestID(ctx))
+}
 
 // returns a loggerGenerator that generates a loggers that write to STDOUT
 // with the level parsed from the string (eg "info")

--- a/httpx/middleware/recovery.go
+++ b/httpx/middleware/recovery.go
@@ -57,13 +57,13 @@ func (h *Recovery) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, 
 	return
 }
 
-type SimpleRecovery struct {
+type BasicRecovery struct {
 	handler httpx.Handler
 }
 
 // ServeHTTPContext implements the httpx.Handler interface. It recovers from
 // panics and returns an error for upstream middleware to handle.
-func (h *SimpleRecovery) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, r *http.Request) (err error) {
+func (h *BasicRecovery) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, r *http.Request) (err error) {
 	defer func() {
 		if v := recover(); v != nil {
 			var ok bool
@@ -77,4 +77,8 @@ func (h *SimpleRecovery) ServeHTTPContext(ctx context.Context, w http.ResponseWr
 	err = h.handler.ServeHTTPContext(ctx, w, r)
 
 	return
+}
+
+func BasicRecover(h httpx.Handler) *BasicRecovery {
+	return &BasicRecovery{handler: h}
 }

--- a/httpx/middleware/reporter.go
+++ b/httpx/middleware/reporter.go
@@ -1,0 +1,33 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/remind101/pkg/httpx"
+	"github.com/remind101/pkg/reporter"
+)
+
+// Reporter is a middleware that adds a Reporter to the request context and adds
+// the request info to the reporter context.
+type Reporter struct {
+	handler  httpx.Handler
+	reporter reporter.Reporter
+}
+
+func (m *Reporter) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	// Add reporter to context.
+	ctx = reporter.WithReporter(ctx, m.reporter)
+
+	// Add the request to the reporter context.
+	reporter.AddRequest(ctx, r)
+
+	// Add the request id to reporter context.
+	reporter.AddContext(ctx, "request_id", httpx.RequestID(ctx))
+
+	return m.handler.ServeHTTPContext(ctx, w, r)
+}
+
+func WithReporter(h httpx.Handler, r reporter.Reporter) *Reporter {
+	return &Reporter{handler: h, reporter: r}
+}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -49,6 +49,17 @@ func TestLogLevel(t *testing.T) {
 	}
 }
 
+func TestWith(t *testing.T) {
+	b := new(bytes.Buffer)
+	l := New(log.New(b, "", 0), INFO)
+	lw := l.With("request_id", "abc")
+	lw.Info("message", "count", 1)
+
+	if got, want := b.String(), "message request_id=abc count=1\n"; got != want {
+		t.Fatalf("With Logger => %q; want %q", got, want)
+	}
+}
+
 func TestWithContextLogger(t *testing.T) {
 	b := new(bytes.Buffer)
 	l := New(log.New(b, "", 0), INFO)


### PR DESCRIPTION
Adds middleware to separate the following:
* Adding a reporter to the context and request info to reporting context.
* Recovering from panics
* Reporting errors returned by handler.

This way, error reporting can happen in one place instead of in both the recovery middleware and error middleware:

``` go
	var h httpx.Handler

	// Recover from panics. A panic is converted to an error. This should be first,
	// even though it means panics in middleware will not be recovered, because
	// later middleware expects endpoint panics to be returned as an error.
	h = middleware.BasicRecover(opts.Router)

	// Handler errors returned by endpoint handler or recovery middleware.
	// Errors will no longer be returned after this middeware.
	h = middleware.HandleError(h, middleware.ReportingErrorHandler)

	// Add reporter to context and request to reporter context.
	h = middleware.WithReporter(h, opts.Reporter)

	// Add the request id to the context.
	h = middleware.ExtractRequestID(h)
```