### PR TITLE
Isolate newrelic middleware into their own packages

### DIFF
--- a/httpx/middleware/newrelic/tracer.go
+++ b/httpx/middleware/newrelic/tracer.go
@@ -1,18 +1,19 @@
-package middleware
+package newrelic
 
 import (
 	"fmt"
 	"net/http"
 
+	"context"
+
 	"github.com/newrelic/go-agent"
 	"github.com/remind101/pkg/httpx"
-	"context"
 )
 
 type NewRelicGoTracer struct {
-	handler  httpx.Handler
-	app      newrelic.Application
-	router   *httpx.Router
+	handler httpx.Handler
+	app     newrelic.Application
+	router  *httpx.Router
 }
 
 func NewRelicGoTracing(h httpx.Handler, router *httpx.Router, app newrelic.Application) httpx.Handler {
@@ -51,3 +52,18 @@ const (
 	newrelic_app = iota
 	newrelic_txn = iota
 )
+
+func templatePath(router *httpx.Router, r *http.Request) string {
+	var tpl string
+
+	route, _, _ := router.Handler(r)
+	if route != nil {
+		tpl = route.GetPathTemplate()
+	}
+
+	if tpl == "" {
+		tpl = r.URL.Path
+	}
+
+	return tpl
+}

--- a/httpx/middleware/opentracing_test.go
+++ b/httpx/middleware/opentracing_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"context"
+
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/remind101/pkg/httpx"
@@ -105,4 +106,13 @@ func runOpentracingTest(t *testing.T, tt *opentracingTest) {
 	if resourceName != tt.expectedResourceName {
 		t.Errorf("Expected %s as resource name, got %s", tt.expectedResourceName, resourceName)
 	}
+}
+
+func newRequest(method, path string) *http.Request {
+	req, err := http.NewRequest(method, path, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	return req
 }

--- a/httpx/middleware/r101newrelic/tracer.go
+++ b/httpx/middleware/r101newrelic/tracer.go
@@ -1,12 +1,13 @@
-package middleware
+package r101newrelic
 
 import (
 	"fmt"
 	"net/http"
 
+	"context"
+
 	"github.com/remind101/newrelic"
 	"github.com/remind101/pkg/httpx"
-	"context"
 )
 
 type NewRelicTracer struct {

--- a/httpx/middleware/r101newrelic/tracer_test.go
+++ b/httpx/middleware/r101newrelic/tracer_test.go
@@ -1,14 +1,15 @@
-package middleware
+package r101newrelic
 
 import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"context"
+
 	"github.com/remind101/newrelic"
 	"github.com/remind101/pkg/httpx"
 	"github.com/stretchr/testify/mock"
-	"context"
 )
 
 type tracerTest struct {


### PR DESCRIPTION
This allows projects to not have to vendor newrelic packages if they aren't using the newrelic middleware