### PR TITLE
Add timeout middleware

### DIFF
--- a/httpx/middleware/timeout.go
+++ b/httpx/middleware/timeout.go
@@ -1,0 +1,133 @@
+package middleware
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/remind101/pkg/httpx"
+)
+
+// TimeoutHandler returns a Handler that runs h with the given time limit.
+//
+// The new Handler calls h.ServeHTTPContext to handle each request, but if a
+// call runs for longer than its time limit, the handler will return an
+// error that satisfies the timeoutError interface, to integrate with the
+// error middleware.
+//
+// After such a timeout, writes by h to its ResponseWriter will return
+// ErrHandlerTimeout.
+//
+// TimeoutHandler buffers all Handler writes to memory and does not
+// support the Hijacker or Flusher interfaces.
+//
+// NOTE This is a modified version of https://godoc.org/net/http#TimeoutHandler
+func TimeoutHandler(h httpx.Handler, dt time.Duration) httpx.Handler {
+	return &timeoutHandler{
+		handler: h,
+		dt:      dt,
+	}
+}
+
+type handlerTimeout string
+
+func (e handlerTimeout) Timeout() bool {
+	return true
+}
+func (e handlerTimeout) Error() string {
+	return string(e)
+}
+
+// ErrHandlerTimeout is returned on ResponseWriter Write calls
+// in handlers which have timed out.
+var ErrHandlerTimeout = handlerTimeout("http: handler timeout")
+
+type timeoutHandler struct {
+	handler httpx.Handler
+	dt      time.Duration
+}
+
+func (h *timeoutHandler) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, r *http.Request) (err error) {
+	ctx, cancelCtx := context.WithTimeout(ctx, h.dt)
+	defer cancelCtx()
+
+	r = r.WithContext(ctx)
+	done := make(chan struct{})
+	tw := &timeoutWriter{
+		w: w,
+		h: make(http.Header),
+	}
+	panicChan := make(chan interface{}, 1)
+	go func() {
+		defer func() {
+			if p := recover(); p != nil {
+				panicChan <- p
+			}
+		}()
+		err = h.handler.ServeHTTPContext(ctx, tw, r)
+		close(done)
+	}()
+	select {
+	case p := <-panicChan:
+		panic(p)
+	case <-done:
+		tw.mu.Lock()
+		defer tw.mu.Unlock()
+		dst := w.Header()
+		for k, vv := range tw.h {
+			dst[k] = vv
+		}
+		if !tw.wroteHeader {
+			tw.code = http.StatusOK
+		}
+		w.WriteHeader(tw.code)
+		w.Write(tw.wbuf.Bytes())
+	case <-ctx.Done():
+		tw.mu.Lock()
+		defer tw.mu.Unlock()
+		tw.timedOut = true
+		err = ErrHandlerTimeout
+	}
+	return err
+}
+
+type timeoutWriter struct {
+	w    http.ResponseWriter
+	h    http.Header
+	wbuf bytes.Buffer
+
+	mu          sync.Mutex
+	timedOut    bool
+	wroteHeader bool
+	code        int
+}
+
+func (tw *timeoutWriter) Header() http.Header { return tw.h }
+
+func (tw *timeoutWriter) Write(p []byte) (int, error) {
+	tw.mu.Lock()
+	defer tw.mu.Unlock()
+	if tw.timedOut {
+		return 0, ErrHandlerTimeout
+	}
+	if !tw.wroteHeader {
+		tw.writeHeader(http.StatusOK)
+	}
+	return tw.wbuf.Write(p)
+}
+
+func (tw *timeoutWriter) WriteHeader(code int) {
+	tw.mu.Lock()
+	defer tw.mu.Unlock()
+	if tw.timedOut || tw.wroteHeader {
+		return
+	}
+	tw.writeHeader(code)
+}
+
+func (tw *timeoutWriter) writeHeader(code int) {
+	tw.wroteHeader = true
+	tw.code = code
+}

--- a/httpx/middleware/timeout_test.go
+++ b/httpx/middleware/timeout_test.go
@@ -1,0 +1,58 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/remind101/pkg/httpx"
+)
+
+func TestTimeoutFailure(t *testing.T) {
+	h := httpx.HandlerFunc(func(ctx context.Context, rw http.ResponseWriter, r *http.Request) error {
+		time.Sleep(100 * time.Millisecond)
+		rw.WriteHeader(http.StatusOK)
+		return nil
+	})
+	th := TimeoutHandler(h, 50*time.Millisecond)
+
+	ctx := context.Background()
+	req, _ := http.NewRequest("GET", "/", nil)
+	resp := httptest.NewRecorder()
+	err := th.ServeHTTPContext(ctx, resp, req)
+
+	if got, want := err.Error(), "http: handler timeout"; got != want {
+		t.Fatalf("err => %v; want %v", got, want)
+	}
+}
+
+func TestTimeoutSuccess(t *testing.T) {
+	h := httpx.HandlerFunc(func(ctx context.Context, rw http.ResponseWriter, r *http.Request) error {
+		rw.WriteHeader(http.StatusOK)
+		fmt.Fprintln(rw, "Hello")
+		return nil
+	})
+	th := TimeoutHandler(h, 50*time.Millisecond)
+
+	ctx := context.Background()
+	req, _ := http.NewRequest("GET", "/", nil)
+	resp := httptest.NewRecorder()
+	err := th.ServeHTTPContext(ctx, resp, req)
+
+	if err != nil {
+		t.Fatalf("expected no error, got %#v", err)
+	}
+
+	if got, want := resp.Result().StatusCode, http.StatusOK; got != want {
+		t.Fatalf("err => %v; want %v", got, want)
+	}
+
+	b, _ := ioutil.ReadAll(resp.Result().Body)
+	if got, want := string(b), "Hello\n"; got != want {
+		t.Fatalf("err => %v; want %v", got, want)
+	}
+}

--- a/httpx/middleware/timeout_test.go
+++ b/httpx/middleware/timeout_test.go
@@ -2,57 +2,106 @@ package middleware
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/remind101/pkg/httpx"
 )
 
-func TestTimeoutFailure(t *testing.T) {
-	h := httpx.HandlerFunc(func(ctx context.Context, rw http.ResponseWriter, r *http.Request) error {
-		time.Sleep(100 * time.Millisecond)
-		rw.WriteHeader(http.StatusOK)
-		return nil
-	})
-	th := TimeoutHandler(h, 50*time.Millisecond)
+type timeoutTest struct {
+	Handler  httpx.Handler
+	Duration time.Duration
+	Err      error
+	Code     int
+	Body     string
+	Panic    error
+}
 
-	ctx := context.Background()
-	req, _ := http.NewRequest("GET", "/", nil)
-	resp := httptest.NewRecorder()
-	err := th.ServeHTTPContext(ctx, resp, req)
+func TestTimeoutHandler(t *testing.T) {
+	tests := []timeoutTest{
+		{ // Success
+			Handler: httpx.HandlerFunc(func(ctx context.Context, rw http.ResponseWriter, r *http.Request) error {
+				rw.WriteHeader(http.StatusOK)
+				fmt.Fprintln(rw, "Hello")
+				return nil
+			}),
+			Duration: 50 * time.Millisecond,
+			Err:      nil,
+			Code:     http.StatusOK,
+			Body:     "Hello\n",
+		},
+		{ // Non 2xx Status Code
+			Handler: httpx.HandlerFunc(func(ctx context.Context, rw http.ResponseWriter, r *http.Request) error {
+				rw.WriteHeader(http.StatusNotFound)
+				return nil
+			}),
+			Duration: 50 * time.Millisecond,
+			Code:     http.StatusNotFound,
+			Err:      nil,
+		},
+		{ // Error
+			Handler: httpx.HandlerFunc(func(ctx context.Context, rw http.ResponseWriter, r *http.Request) error {
+				return errors.New("boom")
+			}),
+			Duration: 50 * time.Millisecond,
+			Err:      errors.New("boom"),
+		},
+		{ // Panic
+			Handler: httpx.HandlerFunc(func(ctx context.Context, rw http.ResponseWriter, r *http.Request) error {
+				panic(errors.New("boom"))
+			}),
+			Duration: 50 * time.Millisecond,
+			Panic:    errors.New("boom"),
+		},
+		{ // Timeout
+			Handler: httpx.HandlerFunc(func(ctx context.Context, rw http.ResponseWriter, r *http.Request) error {
+				time.Sleep(100 * time.Millisecond)
+				rw.WriteHeader(http.StatusOK)
+				return nil
+			}),
+			Duration: 50 * time.Millisecond,
+			Err:      ErrHandlerTimeout,
+		},
+	}
 
-	if got, want := err.Error(), "http: handler timeout"; got != want {
-		t.Fatalf("err => %v; want %v", got, want)
+	for _, tt := range tests {
+		runTimeoutTest(tt, t)
 	}
 }
 
-func TestTimeoutSuccess(t *testing.T) {
-	h := httpx.HandlerFunc(func(ctx context.Context, rw http.ResponseWriter, r *http.Request) error {
-		rw.WriteHeader(http.StatusOK)
-		fmt.Fprintln(rw, "Hello")
-		return nil
-	})
-	th := TimeoutHandler(h, 50*time.Millisecond)
-
+func runTimeoutTest(tt timeoutTest, t *testing.T) {
+	defer func() {
+		if got, want := recover(), tt.Panic; !reflect.DeepEqual(got, want) {
+			t.Errorf("got: %#v; expected %#v", got, want)
+		}
+	}()
+	th := TimeoutHandler(tt.Handler, tt.Duration)
 	ctx := context.Background()
 	req, _ := http.NewRequest("GET", "/", nil)
 	resp := httptest.NewRecorder()
 	err := th.ServeHTTPContext(ctx, resp, req)
 
-	if err != nil {
-		t.Fatalf("expected no error, got %#v", err)
+	if got, want := err, tt.Err; !reflect.DeepEqual(got, want) {
+		t.Errorf("got: %#v; expected %#v", got, want)
 	}
 
-	if got, want := resp.Result().StatusCode, http.StatusOK; got != want {
-		t.Fatalf("err => %v; want %v", got, want)
+	if tt.Code > 0 {
+		if got, want := resp.Result().StatusCode, tt.Code; got != want {
+			t.Errorf("got: %#v; expected %#v", got, want)
+		}
 	}
 
-	b, _ := ioutil.ReadAll(resp.Result().Body)
-	if got, want := string(b), "Hello\n"; got != want {
-		t.Fatalf("err => %v; want %v", got, want)
+	if tt.Body != "" {
+		b, _ := ioutil.ReadAll(resp.Result().Body)
+		if got, want := string(b), tt.Body; got != want {
+			t.Errorf("got: %#v; expected %#v", got, want)
+		}
 	}
+
 }


### PR DESCRIPTION
This is based on https://godoc.org/net/http#TimeoutHandler and modified to return an error and allow downstream middleware to render an appropriate response. 