### PR TITLE
Only write in timeout handler if something to write

### DIFF
--- a/httpx/middleware/timeout.go
+++ b/httpx/middleware/timeout.go
@@ -82,7 +82,7 @@ func (h *timeoutHandler) ServeHTTPContext(ctx context.Context, rw http.ResponseW
 		//
 		// It is possible that the handler merely returned an error in which case
 		// a middleware may write a response, so we must not always write one here.
-		if tw.modified {
+		if tw.modified || len(tw.Header()) > 0 {
 			dst := rw.Header()
 			for k, vv := range tw.h {
 				dst[k] = vv
@@ -114,7 +114,6 @@ type timeoutWriter struct {
 }
 
 func (tw *timeoutWriter) Header() http.Header {
-	tw.modified = true
 	return tw.h
 }
 

--- a/httpx/middleware/timeout.go
+++ b/httpx/middleware/timeout.go
@@ -82,7 +82,7 @@ func (h *timeoutHandler) ServeHTTPContext(ctx context.Context, rw http.ResponseW
 		//
 		// It is possible that the handler merely returned an error in which case
 		// a middleware may write a response, so we must not always write one here.
-		if tw.modified || len(tw.Header()) > 0 {
+		if tw.isModified() {
 			dst := rw.Header()
 			for k, vv := range tw.h {
 				dst[k] = vv
@@ -144,4 +144,8 @@ func (tw *timeoutWriter) WriteHeader(code int) {
 func (tw *timeoutWriter) writeHeader(code int) {
 	tw.wroteHeader = true
 	tw.code = code
+}
+
+func (tw *timeoutWriter) isModified() bool {
+	return tw.modified || len(tw.Header()) > 0
 }

--- a/svc/svc_test.go
+++ b/svc/svc_test.go
@@ -59,7 +59,7 @@ func TestStandardHandler(t *testing.T) {
 			},
 			StatusCode: 503,
 			Body:       `{"error":"http: handler timeout"}` + "\n",
-			ErrFrame:   "timeout.go:94",
+			ErrFrame:   "timeout.go:100",
 		},
 	}
 

--- a/svc/svc_test.go
+++ b/svc/svc_test.go
@@ -59,7 +59,7 @@ func TestStandardHandler(t *testing.T) {
 			},
 			StatusCode: 503,
 			Body:       `{"error":"http: handler timeout"}` + "\n",
-			ErrFrame:   "timeout.go:92",
+			ErrFrame:   "timeout.go:94",
 		},
 	}
 


### PR DESCRIPTION
Previously if handler times out and doesn't write a response, the time handler would write a 200 status by default. Now it will not touch the response, and let an error middleware write the appropriate response.