### PR TITLE
Fix tracing status codes on error.

### DIFF
--- a/httpx/middleware/error.go
+++ b/httpx/middleware/error.go
@@ -107,5 +107,6 @@ func (h *Error) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, r *
 		f(ctx, err, w, r)
 	}
 
-	return nil
+	// Pass the error up for any other middleware to use.
+	return err
 }

--- a/httpx/middleware/error_test.go
+++ b/httpx/middleware/error_test.go
@@ -82,8 +82,8 @@ func TestErrorMiddleware(t *testing.T) {
 		resp := httptest.NewRecorder()
 		ctx := reporter.WithReporter(context.Background(), reporter.NewLogReporter())
 		err := h.ServeHTTPContext(ctx, resp, req)
-		if err != nil {
-			t.Fatal("Expected no error to be returned because it was handled")
+		if err != tt.Error {
+			t.Fatal("Expected error to be returned")
 		}
 
 		if got, want := resp.Body.String(), tt.Body; got != want {

--- a/svc/svc.go
+++ b/svc/svc.go
@@ -67,10 +67,6 @@ func NewStandardHandler(opts HandlerOpts) http.Handler {
 	// later middleware expects endpoint panics to be returned as an error.
 	h = middleware.BasicRecover(h)
 
-	// Add request tracing. Must go before the HandleError middleware in order
-	// to capture any errors from the endpoint handler.
-	h = middleware.OpentracingTracing(h, opts.Router)
-
 	// Handler errors returned by endpoint handler or recovery middleware.
 	// Errors will no longer be returned after this middeware.
 	errorHandler := opts.ErrorHandler
@@ -78,6 +74,10 @@ func NewStandardHandler(opts HandlerOpts) http.Handler {
 		errorHandler = middleware.ReportingErrorHandler
 	}
 	h = middleware.HandleError(h, errorHandler)
+
+	// Add request tracing. Must go after the HandleError middleware in order
+	// to capture the status code written to the response.
+	h = middleware.OpentracingTracing(h, opts.Router)
 
 	// Insert logger into context and log requests at INFO level.
 	h = middleware.LogTo(h, middleware.LoggerWithRequestID)


### PR DESCRIPTION
By allowing the error handler middleware to pass
the error up, the opentracing middleware can access
it and add it to the trace.

By moving the opentracing middleware after the
error handling middleare, the response will have
been written and the trace status code will be
correct.

NOTE: I'm pretty convinced at this point that we should
remove the error handling middleware and provide helper
methods instead, to be used in the endpoint handlers.
As an added benefit, there will be no more need to return an error
so we can conform to the http.Handler interface.