### PR TITLE
Extract error handling from middleware

### DIFF
--- a/httpx/error.go
+++ b/httpx/error.go
@@ -1,0 +1,54 @@
+package httpx
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/remind101/pkg/reporter"
+)
+
+func Error(ctx context.Context, err error, rw http.ResponseWriter, r *http.Request) {
+	reporter.Report(ctx, err)
+	EncodeError(err, rw)
+}
+
+type temporaryError interface {
+	Temporary() bool // Is the error temporary?
+}
+
+type timeoutError interface {
+	Timeout() bool // Is the error a timeout?
+}
+
+type statusCoder interface {
+	StatusCode() int
+}
+
+func EncodeError(err error, rw http.ResponseWriter) {
+	rw.Header().Set("Content-Type", "application/json")
+	rw.WriteHeader(ErrorStatusCode(err))
+
+	errorResp := map[string]string{
+		"error": err.Error(),
+	}
+
+	json.NewEncoder(rw).Encode(errorResp)
+}
+
+func ErrorStatusCode(err error) int {
+	rootErr := errors.Cause(err)
+	if e, ok := rootErr.(statusCoder); ok {
+		return e.StatusCode()
+	}
+	if e, ok := rootErr.(temporaryError); ok && e.Temporary() {
+		return http.StatusServiceUnavailable
+	}
+
+	if e, ok := rootErr.(timeoutError); ok && e.Timeout() {
+		return http.StatusServiceUnavailable
+	}
+
+	return http.StatusInternalServerError
+}

--- a/httpx/error_test.go
+++ b/httpx/error_test.go
@@ -1,0 +1,80 @@
+package httpx_test
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/remind101/pkg/httpx"
+	"github.com/remind101/pkg/reporter"
+)
+
+type tmpError string
+
+func (te tmpError) Error() string {
+	return string(te)
+}
+
+func (te tmpError) Temporary() bool {
+	return true
+}
+
+type statusCodeError struct {
+	Err        error
+	statusCode int
+}
+
+func (s statusCodeError) Error() string {
+	return s.Err.Error()
+}
+
+func (s statusCodeError) StatusCode() int {
+	return s.statusCode
+}
+
+func TestError(t *testing.T) {
+	tests := []struct {
+		Error error
+		Body  string
+		Code  int
+	}{
+		{
+			Error: errors.New("boom"),
+			Body:  `{"error":"boom"}` + "\n",
+			Code:  500,
+		},
+		{
+			Error: tmpError("service unavailable"),
+			Body:  `{"error":"service unavailable"}` + "\n",
+			Code:  503,
+		},
+		{
+			Error: &net.DNSError{Err: "no such host", IsTimeout: true},
+			Body:  `{"error":"lookup : no such host"}` + "\n",
+			Code:  503,
+		},
+		{
+			Error: statusCodeError{Err: errors.New("invalid request"), statusCode: 400},
+			Body:  `{"error":"invalid request"}` + "\n",
+			Code:  400,
+		},
+	}
+
+	for _, tt := range tests {
+		r, _ := http.NewRequest("GET", "/", nil)
+		rw := httptest.NewRecorder()
+		ctx := reporter.WithReporter(context.Background(), reporter.NewLogReporter())
+		httpx.Error(ctx, tt.Error, rw, r)
+
+		if got, want := rw.Body.String(), tt.Body; got != want {
+			t.Fatalf("Body => %#v; want %#v", got, want)
+		}
+
+		if got, want := rw.Code, tt.Code; got != want {
+			t.Fatalf("Status => %v; want %v", got, want)
+		}
+	}
+}

--- a/httpx/middleware/error_test.go
+++ b/httpx/middleware/error_test.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"errors"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,91 +9,7 @@ import (
 	"context"
 
 	"github.com/remind101/pkg/httpx"
-	"github.com/remind101/pkg/reporter"
 )
-
-type tmpError string
-
-func (te tmpError) Error() string {
-	return string(te)
-}
-
-func (te tmpError) Temporary() bool {
-	return true
-}
-
-type statusCodeError struct {
-	Err        error
-	statusCode int
-}
-
-func (s statusCodeError) Error() string {
-	return s.Err.Error()
-}
-
-func (s statusCodeError) StatusCode() int {
-	return s.statusCode
-}
-
-func TestErrorMiddleware(t *testing.T) {
-	tests := []struct {
-		Error        error
-		Body         string
-		Code         int
-		ErrorHandler ErrorHandlerFunc
-	}{
-		{
-			Error: errors.New("boom"),
-			Body:  "boom\n",
-			Code:  500,
-		},
-		{
-			Error: tmpError("service unavailable"),
-			Body:  "service unavailable\n",
-			Code:  503,
-		},
-		{
-			Error: &net.DNSError{Err: "no such host", IsTimeout: true},
-			Body:  "lookup : no such host\n",
-			Code:  503,
-		},
-		{
-			Error: statusCodeError{Err: errors.New("invalid request"), statusCode: 400},
-			Body:  "invalid request\n",
-			Code:  400,
-		},
-		{
-			Error:        errors.New("boom"),
-			Body:         "{\"error\":\"boom\"}\n",
-			Code:         500,
-			ErrorHandler: JSONReportingErrorHandler,
-		},
-	}
-
-	for _, tt := range tests {
-		h := &Error{
-			handler: httpx.HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-				return tt.Error
-			}),
-			ErrorHandler: tt.ErrorHandler,
-		}
-		req, _ := http.NewRequest("GET", "/", nil)
-		resp := httptest.NewRecorder()
-		ctx := reporter.WithReporter(context.Background(), reporter.NewLogReporter())
-		err := h.ServeHTTPContext(ctx, resp, req)
-		if err != tt.Error {
-			t.Fatal("Expected error to be returned")
-		}
-
-		if got, want := resp.Body.String(), tt.Body; got != want {
-			t.Fatalf("Body => %#v; want %#v", got, want)
-		}
-
-		if got, want := resp.Code, tt.Code; got != want {
-			t.Fatalf("Status => %v; want %v", got, want)
-		}
-	}
-}
 
 func TestErrorWithHandler(t *testing.T) {
 	var called bool
@@ -112,7 +27,10 @@ func TestErrorWithHandler(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/path", nil)
 	resp := httptest.NewRecorder()
 
-	h.ServeHTTPContext(ctx, resp, req)
+	err := h.ServeHTTPContext(ctx, resp, req)
+	if err != errors.New("boom") {
+		t.Fatal("Expected error to be returned")
+	}
 
 	if !called {
 		t.Fatal("Expected the error handler to be called")

--- a/httpx/middleware/error_test.go
+++ b/httpx/middleware/error_test.go
@@ -13,13 +13,14 @@ import (
 
 func TestErrorWithHandler(t *testing.T) {
 	var called bool
+	boomErr := errors.New("boom")
 
 	h := &Error{
 		ErrorHandler: func(ctx context.Context, err error, w http.ResponseWriter, r *http.Request) {
 			called = true
 		},
 		handler: httpx.HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-			return errors.New("boom")
+			return boomErr
 		}),
 	}
 
@@ -28,7 +29,7 @@ func TestErrorWithHandler(t *testing.T) {
 	resp := httptest.NewRecorder()
 
 	err := h.ServeHTTPContext(ctx, resp, req)
-	if err != errors.New("boom") {
+	if err != boomErr {
 		t.Fatal("Expected error to be returned")
 	}
 


### PR DESCRIPTION
This allows handlers to use error handling functions
directly if they want to.