### PR TITLE
Add graceful shutdown

### DIFF
--- a/svc/svc.go
+++ b/svc/svc.go
@@ -137,6 +137,10 @@ func RunServer(h http.Handler, port string, writeTimeout time.Duration) {
 	select {
 	case sig := <-sigCh:
 		fmt.Println("Received signal, stopping.", "signal", sig)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		srv.Shutdown(ctx)
 	// Cleanup
 	case err := <-errCh:
 		fmt.Println(err)


### PR DESCRIPTION
This has been available since 1.8
https://godoc.org/net/http#Server.Shutdown

I swapped the way the goroutine works in RunServer to be more like the example in Server.Shutdown documentation. Now the goroutine listens for the signal, and the main goroutine runs the server. I think its cleaner that way.