### PR TITLE
Timeouts

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -86,7 +86,8 @@ func main() {
 		HandlerTimeout: 5 * time.Second,
 	})
 
-	svc.RunServer(h)
+	s := svc.BuildServer(h)
+	svc.RunServer(s)
 }
 
 type Error struct {

--- a/example/main.go
+++ b/example/main.go
@@ -86,7 +86,7 @@ func main() {
 		HandlerTimeout: 5 * time.Second,
 	})
 
-	s := svc.BuildServer(h)
+	s := svc.NewServer(h)
 	svc.RunServer(s)
 }
 

--- a/example/main.go
+++ b/example/main.go
@@ -86,7 +86,7 @@ func main() {
 		HandlerTimeout: 5 * time.Second,
 	})
 
-	svc.RunServer(h, "8080", 5*time.Second)
+	svc.RunServer(h)
 }
 
 type Error struct {

--- a/svc/svc.go
+++ b/svc/svc.go
@@ -15,7 +15,7 @@
 //			Reporter: env.Reporter,
 //	})
 //
-// 	s := svc.BuildServer(h, WithPort("8080"))
+// 	s := svc.NewServer(h, WithPort("8080"))
 //  svc.RunServer(s)
 // }
 package svc
@@ -108,8 +108,8 @@ func NewStandardHandler(opts HandlerOpts) http.Handler {
 	return middleware.BackgroundContext(h)
 }
 
-// BuildServerOpt allows users to customize the http.Server used by RunServer.
-type BuildServerOpt func(*http.Server)
+// NewServerOpt allows users to customize the http.Server used by RunServer.
+type NewServerOpt func(*http.Server)
 
 // ServerDefaults specifies default server options to use for RunServer.
 var ServerDefaults = func(srv *http.Server) {
@@ -120,18 +120,18 @@ var ServerDefaults = func(srv *http.Server) {
 }
 
 // WithPort sets the port for the server to run on.
-func WithPort(port string) BuildServerOpt {
+func WithPort(port string) NewServerOpt {
 	return func(srv *http.Server) {
 		srv.Addr = ":" + port
 	}
 }
 
-// BuildServer offers some convenience and good defaults for creating an http.Server
-func BuildServer(h http.Handler, opts ...BuildServerOpt) *http.Server {
+// NewServer offers some convenience and good defaults for creating an http.Server
+func NewServer(h http.Handler, opts ...NewServerOpt) *http.Server {
 	srv := &http.Server{Handler: h}
 
 	// Prepend defaults to server options.
-	opts = append([]BuildServerOpt{ServerDefaults}, opts...)
+	opts = append([]NewServerOpt{ServerDefaults}, opts...)
 	for _, opt := range opts {
 		opt(srv)
 	}

--- a/svc/svc.go
+++ b/svc/svc.go
@@ -15,7 +15,7 @@
 //			Reporter: env.Reporter,
 //	})
 //
-// 	svc.RunServer(h, "80", 5*time.Second)
+// 	svc.RunServer(h, WithPort("8080"))
 // }
 package svc
 


### PR DESCRIPTION
Adds some default server timeouts and updates the signature of RunServer to allow easier customization.

NOTE: ReadHeaderTimeout instead of ReadTimeout because:

``` golang
    // ReadTimeout is the maximum duration for reading the entire
    // request, including the body.
    //
    // Because ReadTimeout does not let Handlers make per-request
    // decisions on each request body's acceptable deadline or
    // upload rate, most users will prefer to use
    // ReadHeaderTimeout. It is valid to use them both.
    ReadTimeout time.Duration

    // ReadHeaderTimeout is the amount of time allowed to read
    // request headers. The connection's read deadline is reset
    // after reading the headers and the Handler can decide what
    // is considered too slow for the body.
    ReadHeaderTimeout time.Duration
```