### PR TITLE
Explicitly specify third party dependencies to test with

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,5 +22,6 @@ jobs:
       - checkout
 
       # specify any bash command here prefixed with `run: `
+      - run: make deps
       - run: go get -v -t -d ./...
       - run: go test ./...

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: deps
+
+# This gets all of the third party dependencies that pkg is known to work well
+# with. We don't want to vendor these here, because they should be vendored by
+# `package main`.
+deps:
+	cat deps | ./get-deps.sh

--- a/deps
+++ b/deps
@@ -1,0 +1,1 @@
+github.com/DataDog/dd-trace-go v0.6.1

--- a/get-deps.sh
+++ b/get-deps.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+while read package version; do
+  go get -u "$package"
+  ( cd "$GOPATH/src/$package" && git checkout "$version" )
+done


### PR DESCRIPTION
Tests are broken on master because DataDog/dd-trace-go decided to remove opentracing support. This sets up some support in this repo that makes it easier for us to test against a specific version of a dependency, without vendoring it within pkg (libraries shouldn't vendor, only `package main`).

The `deps` file allows us to specify known working/expected versions of dependencies and should be used as a hint for anything that intends to use pkg.