### PR TITLE
Decouple opentracing/svc from httpx.Router

### DIFF
--- a/httpx/middleware/opentracing.go
+++ b/httpx/middleware/opentracing.go
@@ -14,15 +14,14 @@ import (
 
 type OpentracingTracer struct {
 	handler httpx.Handler
-	router  *httpx.Router
 }
 
-func OpentracingTracing(h httpx.Handler, router *httpx.Router) *OpentracingTracer {
-	return &OpentracingTracer{h, router}
+func OpentracingTracing(h httpx.Handler) *OpentracingTracer {
+	return &OpentracingTracer{h}
 }
 
 func (h *OpentracingTracer) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-	path := otTemplatePath(h.router, r)
+	path := otTemplatePath(ctx)
 	route := fmt.Sprintf("%s %s", r.Method, path)
 
 	var span opentracing.Span
@@ -57,10 +56,10 @@ func (h *OpentracingTracer) ServeHTTPContext(ctx context.Context, w http.Respons
 	return reqErr
 }
 
-func otTemplatePath(router *httpx.Router, r *http.Request) string {
+func otTemplatePath(ctx context.Context) string {
 	var tpl string
 
-	route, _, _ := router.Handler(r)
+	route := httpx.RouteFromContext(ctx)
 	if route != nil {
 		tpl = route.GetPathTemplate()
 	}

--- a/httpx/middleware/opentracing_test.go
+++ b/httpx/middleware/opentracing_test.go
@@ -92,13 +92,14 @@ func runOpentracingTest(t *testing.T, tt *opentracingTest) {
 
 	m = &OpentracingTracer{
 		handler: r,
-		router:  r,
 	}
 
 	ctx := context.Background()
 	resp := httptest.NewRecorder()
 
-	if err := m.ServeHTTPContext(ctx, resp, tt.req); err != nil {
+	route, _, _ := r.Handler(tt.req)
+
+	if err := m.ServeHTTPContext(httpx.WithRoute(ctx, route), resp, tt.req); err != nil {
 		t.Fatal(err)
 	}
 

--- a/svc/handler.go
+++ b/svc/handler.go
@@ -31,7 +31,7 @@ import (
 )
 
 type HandlerOpts struct {
-	Router            *httpx.Router
+	Router            httpx.Handler
 	Reporter          reporter.Reporter
 	ForwardingHeaders []string
 	BasicAuth         string
@@ -44,7 +44,7 @@ type HandlerOpts struct {
 // Order is pretty important as some middleware depends on others having run
 // already.
 func NewStandardHandler(opts HandlerOpts) http.Handler {
-	h := httpx.Handler(opts.Router)
+	h := opts.Router
 
 	if opts.HandlerTimeout != 0 {
 		// Timeout requests after the given Timeout duration.
@@ -66,7 +66,7 @@ func NewStandardHandler(opts HandlerOpts) http.Handler {
 
 	// Add request tracing. Must go after the HandleError middleware in order
 	// to capture the status code written to the response.
-	h = middleware.OpentracingTracing(h, opts.Router)
+	h = middleware.OpentracingTracing(h)
 
 	// Insert logger into context and log requests at INFO level.
 	h = middleware.LogTo(h, middleware.LoggerWithRequestID)

--- a/svc/handler.go
+++ b/svc/handler.go
@@ -39,11 +39,10 @@ type HandlerOpts struct {
 	HandlerTimeout    time.Duration
 }
 
-// NewStandardHandler returns an http.Handler with a standard middleware stack.
-// The last middleware added is the first middleware to handle the request.
-// Order is pretty important as some middleware depends on others having run
-// already.
-func NewStandardHandler(opts HandlerOpts) http.Handler {
+// NewHandler returns an httpx.Handler with a standard middleware stack.  The
+// last middleware added is the first middleware to handle the request.  Order
+// is pretty important as some middleware depends on others having run already.
+func NewHandler(opts HandlerOpts) httpx.Handler {
 	h := opts.Router
 
 	if opts.HandlerTimeout != 0 {
@@ -94,5 +93,11 @@ func NewStandardHandler(opts HandlerOpts) http.Handler {
 
 	// Wrap the route in middleware to add a context.Context. This middleware must be
 	// last as it acts as the adaptor between http.Handler and httpx.Handler.
+	return h
+}
+
+// NewStandardHandler returns an http.Handler with a standard middleware stack.
+func NewStandardHandler(opts HandlerOpts) http.Handler {
+	h := NewHandler(opts)
 	return middleware.BackgroundContext(h)
 }


### PR DESCRIPTION
There's two scenarios I've run into where this would help:

1. I want to be able to add additional middleware at the top, or the bottom of the stack. 
2. In some instances, I don't want to or need to use httpx.Router (e.g. when using Twirp)

