### PR TITLE
Remove recover in Env.Close()

### DIFF
--- a/svc/env.go
+++ b/svc/env.go
@@ -49,7 +49,6 @@ func InitAll() Env {
 		Close: func() {
 			traceCloser()
 			metricsCloser()
-			reporter.Monitor(ctx)
 		},
 	}
 }


### PR DESCRIPTION
This doesn't actually work. To recover from a panic in main() the recover must happen directly in a deferred function called from main.