### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/httpx/middleware/logger.go
+++ b/httpx/middleware/logger.go
@@ -20,7 +20,7 @@ func LoggerWithRequestID(ctx context.Context, r *http.Request) logger.Logger {
 	return logger.DefaultLogger.With("request_id", httpx.RequestID(ctx))
 }
 
-// returns a loggerGenerator that generates a loggers that write to STDOUT
+// StdoutLoggerWithLevel returns a loggerGenerator that generates a loggers that write to STDOUT
 // with the level parsed from the string (eg "info")
 // If the string isnt parsable, it defaults to "debug"
 func StdoutLoggerWithLevel(lvl string) loggerGenerator {

--- a/httpx/router.go
+++ b/httpx/router.go
@@ -122,7 +122,7 @@ func WithVars(ctx context.Context, vars map[string]string) context.Context {
 	return context.WithValue(ctx, varsKey, vars)
 }
 
-// WithVars adds the current Route to the context.Context.
+// WithRoute adds the current Route to the context.Context.
 func WithRoute(ctx context.Context, r *Route) context.Context {
 	return context.WithValue(ctx, routeKey, r)
 }
@@ -182,7 +182,7 @@ func (r *Route) URLPath(pairs ...string) (*url.URL, error) {
 	return r.route.URLPath(pairs...)
 }
 
-// Returns the path template for this route, if any.
+// GetPathTemplate returns the path template for this route, if any.
 func (r *Route) GetPathTemplate() string {
 	return r.pathTpl
 }

--- a/metrics/metricshttpx/middleware.go
+++ b/metrics/metricshttpx/middleware.go
@@ -12,7 +12,7 @@ import (
 	"github.com/remind101/pkg/metrics"
 )
 
-// ResponseTimeReporter reports timing metrics using metrics package
+// NewResponseTimeReporter reports timing metrics using metrics package
 //
 // Usage:
 //   r := httpx.NewRouter()

--- a/reporter/config/config.go
+++ b/reporter/config/config.go
@@ -9,7 +9,7 @@ import (
 	"github.com/remind101/pkg/reporter/rollbar"
 )
 
-// Returns a MultiReporter from URL strings such as:
+// NewReporterFromUrls returns a MultiReporter from URL strings such as:
 // "hb://api.honeybadger.io/?key=hbkey&environment=hbenv" or
 // "rollbar://api.rollbar.com/?key=rollbarkey&environment=rollbarenv"
 func NewReporterFromUrls(urls []string) (reporter.Reporter, error) {

--- a/reporter/hb2/hb2.go
+++ b/reporter/hb2/hb2.go
@@ -44,7 +44,7 @@ func (r *HbReporter) GetConfig() *honeybadger.Configuration {
 	return r.client.Config
 }
 
-// Report reports the error to honeybadger.
+// ReportWithLevel reports reports the error to honeybadger.
 func (r *HbReporter) ReportWithLevel(ctx context.Context, level string, err error) error {
 	extras := []interface{}{}
 

--- a/reporter/logger.go
+++ b/reporter/logger.go
@@ -20,7 +20,7 @@ func NewLogReporter() *LogReporter {
 	return &LogReporter{}
 }
 
-// Report logs the error to the Logger.
+// ReportWithLevel reports logs the error to the Logger.
 func (h *LogReporter) ReportWithLevel(ctx context.Context, level string, err error) error {
 	var file, line string
 	var stack errors.StackTrace

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -34,7 +34,7 @@ type flusher interface {
 // ReporterFunc is a function signature that conforms to the Reporter interface.
 type ReporterFunc func(context.Context, string, error) error
 
-// Report implements the Reporter interface.
+// ReportWithLevel reports implements the Reporter interface.
 func (f ReporterFunc) ReportWithLevel(ctx context.Context, level string, err error) error {
 	return f(ctx, level, err)
 }


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?