### PR TITLE
Add push panic to channel and ignore panic functions

### DIFF
--- a/deps
+++ b/deps
@@ -1,1 +1,2 @@
 gopkg.in/DataDog/dd-trace-go.v1/ddtrace v1.2.2
+github.com/go-redis/redis v6.15.2

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -99,13 +99,16 @@ func reportWithLevel(ctx context.Context, level string, err error) error {
 }
 
 // Monitors and reports panics. Useful in goroutines.
+//
+// Note: this RE-THROWS the panic after logging it
+//
 // Example:
 //   ctx := reporter.WithReporter(context.Background(), hb2.NewReporter(hb2.Config{}))
 //   ...
 //   go func(ctx context.Context) {
 //     defer reporter.Monitor(ctx)
 //     ...
-//     panic("oh noes") // will report, then crash.
+//     panic("oh noes") // will report, then panic with a wrapped error.
 //   }(ctx)
 func Monitor(ctx context.Context) {
 	if err := errors.Recover(ctx, recover()); err != nil {


### PR DESCRIPTION
Add these functions to be used here: https://github.com/remind101/r101-experiments/pull/138

This is different than what I originally had there, since I see the intention with these functions that re-throw the panic, is that you can use them together like:

```
go func() {
  defer errors.IgnorePanic()
  defer errors.PushErrorToChannel(ctx, errChan)
  defer reporter.Monitor(ctx)

  SomethingDangerous()
}()
```