### PR TITLE
Add warn log level

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -16,6 +16,7 @@ type Level int
 const (
 	OFF Level = iota
 	ERROR
+	WARN
 	INFO
 	DEBUG
 )
@@ -26,6 +27,8 @@ func ParseLevel(lvl string) Level {
 		return OFF
 	case "error":
 		return ERROR
+	case "warn":
+		return WARN
 	case "info":
 		return INFO
 	case "debug":

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -42,7 +42,7 @@ func testInfo(msg string, pairs ...interface{}) string {
 func TestLogLevel(t *testing.T) {
 
 	b := new(bytes.Buffer)
-	l := New(log.New(b, "", 0), ERROR)
+	l := New(log.New(b, "", 0), WARN)
 	Info(WithLogger(context.Background(), l), "test info")
 	if got, want := b.String(), ""; got != want {
 		t.Fatalf("ontext Logger => %q; want %q", got, want)


### PR DESCRIPTION
For when your thing isn't an `error`, but is more important than just `info`.

Created so that there's a log level separate from what svc logs for requests, since we sometimes want to turn those off.