### PR TITLE
Ensure JSONDecoder reads all the way to EOF

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     docker:
       # specify the version
-      - image: circleci/golang:1.9
+      - image: circleci/golang:1.14
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/client/request/handlers_test.go
+++ b/client/request/handlers_test.go
@@ -1,6 +1,8 @@
 package request_test
 
 import (
+	"bytes"
+	"io"
 	"net/http"
 	"testing"
 
@@ -82,4 +84,108 @@ func TestDebugLogging(t *testing.T) {
 	r.Handlers.Send.Append(request.ResponseLogger)
 	sendRequest(r, http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 	}))
+}
+
+func TestInvalidJSON(t *testing.T) {
+	invalidJSONs := [][]byte{
+		[]byte("{\"value\": \"hello\"}{\"value\": \"world\"}"),
+		[]byte("{\"value\": \"hello\"}42"),
+		[]byte("42"),
+	}
+
+	for _, invalidJSON := range invalidJSONs {
+		var data JSONdata
+		r := newTestRequest("POST", "/foo", nil, &data)
+		sendRequest(r, http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			rw.Write(invalidJSON)
+		}))
+
+		if r.Error == nil {
+			t.Errorf("malformed JSON %s should produce an error.", invalidJSON)
+		}
+	}
+}
+
+func TestValidJSON(t *testing.T) {
+	validJSONs := [][]byte{
+		[]byte("{\"value\": \"hello\"}"),
+		[]byte("{\"value\": \"hello\"}\r\n"),
+		[]byte("{\"value\": \"hello\"}\n"),
+		[]byte("     {\"value\": \"hello\"}     "),
+	}
+
+	for _, validJSON := range validJSONs {
+		var data JSONdata
+		r := newTestRequest("POST", "/foo", nil, &data)
+		sendRequest(r, http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			rw.Write(validJSON)
+		}))
+
+		if r.Error != nil {
+			t.Errorf("valid JSON %s produced error: %v", validJSON, r.Error)
+		}
+		if data.Value != "hello" {
+			t.Errorf("%s should have produced value \"hello\", got \"%v\"", validJSON, data.Value)
+		}
+	}
+}
+
+// for any io.Reader, .Read() may read some bytes and return EOF, or it may
+// read zero bytes and return EOF. zeroReadEOFReader wraps any io.Reader such
+// that it always does the latter.
+//
+// This is important because for an http connection to be reused, not only must
+// all the bytes be read, but the response body must be read to EOF. Thus this
+// is useful to test for handlers which might might read all the bytes (because
+// they have some other means of knowing the length of the content) but fail to
+// make the final call that returns zero bytes and EOF.
+type zeroReadEOFReader struct {
+	source  io.Reader
+	sentEOF bool
+}
+
+func (c *zeroReadEOFReader) Close() error {
+	c.source = nil
+	return nil
+}
+
+func (c *zeroReadEOFReader) Read(buf []byte) (int, error) {
+	bytesRead, err := c.source.Read(buf)
+	if bytesRead != 0 && err == io.EOF {
+		err = nil
+	}
+	c.sentEOF = err == io.EOF
+	return bytesRead, err
+}
+
+func TestJSONReadsToEOF(t *testing.T) {
+	var data JSONdata
+	r := newTestRequest("POST", "/foo", nil, &data)
+	r.HTTPResponse = &http.Response{}
+	body := zeroReadEOFReader{source: bytes.NewReader([]byte("{\"value\": \"hello\"}"))}
+	r.HTTPResponse.Body = &body
+	request.JSONDecoder.Fn(r)
+	if r.Error != nil {
+		t.Errorf("handler returned error: %v", r.Error)
+	}
+	if data.Value != "hello" {
+		t.Errorf("Value should be \"hello\", got %v", data.Value)
+	}
+	if !body.sentEOF {
+		t.Error("handler did not read EOF")
+	}
+}
+
+func TestJSONDecodeNoData(t *testing.T) {
+	r := newTestRequest("POST", "/foo", nil, nil)
+	r.HTTPResponse = &http.Response{}
+	body := zeroReadEOFReader{source: bytes.NewReader([]byte("{\"value\": \"hello\"}"))}
+	r.HTTPResponse.Body = &body
+	request.JSONDecoder.Fn(r)
+	if r.Error != nil {
+		t.Errorf("handler returned error: %v", r.Error)
+	}
+	if !body.sentEOF {
+		t.Error("handler did not read EOF")
+	}
 }


### PR DESCRIPTION
JSONDecoder would not always call .Read() enough times to get an EOF.
When this happens, the connection is not returned to the connection
pool. Instead, it's closed with data still in the receive buffer, which
results in the kernel sending a TCP RST.

This is happening nearly every time in r101-experiments, which is really
bad for performance.

Further reading: https://ahmet.im/blog/golang-json-decoder-pitfalls/

The author of that article argues for using json.Unmarshal, but I
believe the concerns can be addressed by using json.Decoder.More() while
retaining the RAM advantages of a streaming parser.