### PR TITLE
Minor improvements to the httpx/errors testing and implementation

### DIFF
--- a/httpx/errors/errors.go
+++ b/httpx/errors/errors.go
@@ -51,10 +51,10 @@ func Recover(ctx context.Context, v interface{}) (e error) {
 	switch err := v.(type) {
 	case nil:
 		e = nil
-	case error:
-		e = New(ctx, err, 0)
 	case *Error:
 		e = err
+	case error:
+		e = New(ctx, err, 0)
 	default:
 		e = New(ctx, fmt.Errorf("%v", err), 0)
 	}
@@ -157,6 +157,9 @@ func genStacktrace(err error, skip int) errors.StackTrace {
 			skip = index + 1
 			break
 		}
+	}
+	if skip >= len(stack) {
+		panic("attempt to skip past more frames than are present in the stack")
 	}
 
 	return stack[skip:]

--- a/httpx/errors/request.go
+++ b/httpx/errors/request.go
@@ -75,9 +75,7 @@ func copyStringArray(values []string) []string {
 		return nil
 	}
 	safeArray := make([]string, len(values))
-	for idx, value := range values {
-		safeArray[idx] = value
-	}
+	copy(safeArray, values)
 	return safeArray
 }
 

--- a/httpx/middleware/timeout.go
+++ b/httpx/middleware/timeout.go
@@ -32,18 +32,21 @@ func TimeoutHandler(h httpx.Handler, dt time.Duration) httpx.Handler {
 	}
 }
 
-type handlerTimeout string
+type handlerTimeout struct {
+	message string
+}
 
 func (e handlerTimeout) Timeout() bool {
 	return true
 }
+
 func (e handlerTimeout) Error() string {
-	return string(e)
+	return e.message
 }
 
 // ErrHandlerTimeout is returned on ResponseWriter Write calls
 // in handlers which have timed out.
-var ErrHandlerTimeout = handlerTimeout("http: handler timeout")
+var ErrHandlerTimeout = &handlerTimeout{"http: handler timeout"}
 
 type timeoutHandler struct {
 	handler httpx.Handler

--- a/svc/svc_test.go
+++ b/svc/svc_test.go
@@ -59,7 +59,7 @@ func TestStandardHandler(t *testing.T) {
 			},
 			StatusCode: 503,
 			Body:       `{"error":"http: handler timeout"}` + "\n",
-			ErrFrame:   "timeout.go:100",
+			ErrFrame:   "timeout.go:103",
 		},
 	}
 


### PR DESCRIPTION
Switched the test to a whitebox (we need to test that some private functions). Added some tests around the genStacktrace funcs on boundries for fetching stack trace frames.

Swapped the order for the Recover function switch statement so it would hit the *Error case.

Minor nit in request.go around copying a string array, which should use `copy` instead of a for loop.