### PR TITLE
Google Cloud Profiler: Never error on startup

### DIFF
--- a/profiling/cloud_profiler.go
+++ b/profiling/cloud_profiler.go
@@ -1,7 +1,9 @@
 package profiling
 
 import (
+	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 
 	"cloud.google.com/go/profiler"
@@ -16,32 +18,122 @@ type GoogleProfilerFlag struct{}
 // This allows us to use Google's nifty profiling UI to view live production
 // profiling. https://cloud.google.com/profiler
 func (f GoogleProfilerFlag) Set(projectID string) error {
+	// Get all of the empire configs from the environment, and make sure they're
+	// set.
+	empire_appname := os.Getenv("EMPIRE_APPNAME")
+	if empire_appname == "" {
+		log.Printf(
+			"%+v",
+			errors.WithStack(
+				fmt.Errorf(
+					"pkg/profiling: GoogleProfilerFlag.Set: missing/blank required env var EMPIRE_APPNAME",
+				),
+			),
+		)
+
+		return nil
+	}
+
+	empire_process := os.Getenv("EMPIRE_PROCESS")
+	if empire_process == "" {
+		log.Printf(
+			"%+v",
+			errors.WithStack(
+				fmt.Errorf(
+					"pkg/profiling: GoogleProfilerFlag.Set: missing/blank required env var EMPIRE_PROCESS",
+				),
+			),
+		)
+
+		return nil
+	}
+
+	empire_release := os.Getenv("EMPIRE_RELEASE")
+	if empire_release == "" {
+		log.Printf(
+			"%+v",
+			errors.WithStack(
+				fmt.Errorf(
+					"pkg/profiling: GoogleProfilerFlag.Set: missing/blank required env var EMPIRE_RELEASE",
+				),
+			),
+		)
+
+		return nil
+	}
+
 	creds := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_CONTENT")
+	if creds == "" {
+		log.Printf(
+			"%+v",
+			errors.WithStack(
+				fmt.Errorf(
+					"pkg/profiling: GoogleProfilerFlag.Set: missing/blank required env var GOOGLE_APPLICATION_CREDENTIALS_CONTENT",
+				),
+			),
+		)
+
+		return nil
+	}
+
 	credsPath := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
+	if credsPath == "" {
+		log.Printf(
+			"%+v",
+			errors.WithStack(
+				fmt.Errorf(
+					"pkg/profiling: GoogleProfilerFlag.Set: missing/blank required env var GOOGLE_APPLICATION_CREDENTIALS",
+				),
+			),
+		)
 
-	if creds != "" {
-		// kludge alert! Our 12-factor way of deploying applications can't pass
-		// configuration to programs except through environment variables, but
-		// the GCP SDK expects the credentials to be in a file at the path of
-		// $GOOGLE_APPLICATION_CREDENTIALS. So, we put the actual credentials
-		// in a different environment variable, and write them to a file.
-		//
-		// If $GOOGLE_APPLICATION_CREDENTIALS_CONTENT isn't set then we do
-		// nothing, since we might be running in an environment where the
-		// credentials might be discovered through other means.
+		return nil
+	}
 
-		if err := ioutil.WriteFile(credsPath, []byte(creds), 0600); err != nil {
-			return errors.Wrap(err, "could not write $GOOGLE_APPLICATION_CREDENTIALS_CONTENT to "+credsPath)
-		}
+	// kludge alert! Our 12-factor way of deploying applications can't pass
+	// configuration to programs except through environment variables, but
+	// the GCP SDK expects the credentials to be in a file at the path of
+	// $GOOGLE_APPLICATION_CREDENTIALS. So, we put the actual credentials
+	// in a different environment variable, and write them to a file.
+	//
+	// If $GOOGLE_APPLICATION_CREDENTIALS_CONTENT isn't set then we do
+	// nothing, since we might be running in an environment where the
+	// credentials might be discovered through other means.
+	if err := ioutil.WriteFile(credsPath, []byte(creds), 0600); err != nil {
+		log.Printf(
+			"%+v",
+			errors.WithStack(
+				fmt.Errorf(
+					"pkg/profiling: GoogleProfilerFlag.Set: could not write $GOOGLE_APPLICATION_CREDENTIALS_CONTENT to %s: %s",
+					credsPath,
+					err,
+				),
+			),
+		)
+
+		return nil
 	}
 
 	cfg := profiler.Config{
-		Service:        os.Getenv("EMPIRE_APPNAME") + "." + os.Getenv("EMPIRE_PROCESS"),
-		ServiceVersion: os.Getenv("EMPIRE_RELEASE"),
+		Service:        fmt.Sprintf("%s.%s", empire_appname, empire_process),
+		ServiceVersion: empire_release,
 		ProjectID:      projectID,
 	}
 
-	return profiler.Start(cfg)
+	err := profiler.Start(cfg)
+	if err != nil {
+		log.Printf(
+			"%+v",
+			errors.WithStack(
+				fmt.Errorf(
+					"pkg/profiling: GoogleProfilerFlag.Set: error starting profiler: %s",
+					err,
+				),
+			),
+		)
+	}
+
+	return nil
 }
 
 func (f GoogleProfilerFlag) String() string {


### PR DESCRIPTION
We've had multiple issues caused by misconfigurations in the google
cloud profiling crashing an app at startup. Because of the way this
package is used with urfave/cli, it's not realistically feasible for the
application developer to handler errors in the app itself.

These changes log any errors that occur, but ensure that no error will
be returned and the application will be able to start up without
failing.